### PR TITLE
feat(showcases): use details and icon with caption molecules

### DIFF
--- a/remotion/compositions/showcases/alpescraft/Details.tsx
+++ b/remotion/compositions/showcases/alpescraft/Details.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
-import {Lottie} from '@remotion/lottie';
-import {useLottie} from '../../../hooks/useLottie';
 import {spring, useCurrentFrame, useVideoConfig} from 'remotion';
+import {TalkDetails} from '../../../design/molecules/TalkDetails';
 
 export const Details: React.FC<{
 	date: string;
@@ -10,114 +9,26 @@ export const Details: React.FC<{
 }> = ({date, time, location}) => {
 	const frame = useCurrentFrame();
 	const {fps} = useVideoConfig();
-	const illustrationDate = useLottie('lf20_ak90tqhe');
-	const illustrationHour = useLottie('lf20_nv5aXa');
-	const illustrationLocation = useLottie('lf20_PgZU3O');
 
 	const durationInFrames = 30;
-	const drop = spring({frame, from: -20, to: 0, fps, durationInFrames});
+	const drop = spring({frame, from: -30, to: -10, fps, durationInFrames});
 	const opacity = spring({frame, from: 0, to: 1, fps, durationInFrames});
 
-	if (!illustrationHour || !illustrationDate || !illustrationLocation) {
-		return null;
-	}
-
 	return (
-		<div
+		<TalkDetails
+			date={date}
+			time={time}
+			location={location}
+			flex={true}
 			style={{
-				fontWeight: 700,
 				fontSize: '25px',
-				color: 'white',
-				position: 'absolute',
-				bottom: '3rem',
-				display: 'flex',
-				width: '100%',
-				justifyContent: 'center',
-				alignItems: 'center',
 				flexWrap: 'wrap',
-				columnGap: '7rem',
+				gap: 60,
 			}}
-		>
-			<div
-				style={{
-					display: 'flex',
-					justifyContent: 'flex-end',
-					alignItems: 'center',
-					gap: '1rem',
-					flex: '1 0 20%',
-				}}
-			>
-				<Lottie
-					style={{
-						width: '110px',
-						filter: 'none',
-					}}
-					playbackRate={1.5}
-					animationData={illustrationDate}
-				/>
-				<span
-					style={{
-						position: 'relative',
-						bottom: drop,
-						opacity,
-					}}
-				>
-					{date}
-				</span>
-			</div>
-			<div
-				style={{
-					display: 'flex',
-					alignItems: 'center',
-					gap: '1rem',
-					flex: '1 0 20%',
-				}}
-			>
-				<Lottie
-					style={{
-						width: '70px',
-						filter: 'none',
-					}}
-					animationData={illustrationLocation}
-				/>
-				<span
-					style={{
-						position: 'relative',
-						bottom: drop,
-						opacity,
-					}}
-				>
-					{location}
-				</span>
-			</div>
-			{time && (
-				<div
-					style={{
-						display: 'flex',
-						justifyContent: 'center',
-						alignItems: 'center',
-						gap: '2rem',
-						flexBasis: '100%',
-					}}
-				>
-					<Lottie
-						style={{
-							width: '50px',
-							filter: 'none',
-						}}
-						animationData={illustrationHour}
-					/>
-					<span
-						style={{
-							position: 'relative',
-							bottom: drop,
-							opacity,
-						}}
-					>
-						{time}
-					</span>
-				</div>
-			)}
-		</div>
+			iconStyle={{
+				opacity,
+				bottom: drop,
+			}}
+		/>
 	);
 };

--- a/remotion/compositions/showcases/alpescraft/Details.tsx
+++ b/remotion/compositions/showcases/alpescraft/Details.tsx
@@ -19,7 +19,6 @@ export const Details: React.FC<{
 			date={date}
 			time={time}
 			location={location}
-			flex={true}
 			style={{
 				fontSize: '25px',
 				flexWrap: 'wrap',

--- a/remotion/compositions/showcases/alpescraft/Details.tsx
+++ b/remotion/compositions/showcases/alpescraft/Details.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
+import {Lottie} from '@remotion/lottie';
+import {useLottie} from '../../../hooks/useLottie';
 import {spring, useCurrentFrame, useVideoConfig} from 'remotion';
-import {TalkDetails} from '../../../design/molecules/TalkDetails';
+import {IconWithCaption} from '../../../design/molecules/IconWithCaption';
 
 export const Details: React.FC<{
 	date: string;
@@ -9,25 +11,68 @@ export const Details: React.FC<{
 }> = ({date, time, location}) => {
 	const frame = useCurrentFrame();
 	const {fps} = useVideoConfig();
+	const illustrationDate = useLottie('lf20_ak90tqhe');
+	const illustrationHour = useLottie('lf20_nv5aXa');
+	const illustrationLocation = useLottie('lf20_PgZU3O');
 
 	const durationInFrames = 30;
-	const drop = spring({frame, from: -30, to: -10, fps, durationInFrames});
+	const drop = spring({frame, from: -20, to: 0, fps, durationInFrames});
 	const opacity = spring({frame, from: 0, to: 1, fps, durationInFrames});
 
+	if (!illustrationHour || !illustrationDate || !illustrationLocation) {
+		return null;
+	}
+
 	return (
-		<TalkDetails
-			date={date}
-			time={time}
-			location={location}
+		<div
 			style={{
+				fontWeight: 700,
 				fontSize: '25px',
+				color: 'white',
+				position: 'absolute',
+				bottom: '3rem',
+				display: 'flex',
+				width: '100%',
+				justifyContent: 'center',
+				alignItems: 'center',
 				flexWrap: 'wrap',
-				gap: 60,
+				columnGap: '7rem',
 			}}
-			iconStyle={{
-				opacity,
-				bottom: drop,
-			}}
-		/>
+		>
+			<IconWithCaption
+				iconifyId="mdi:calendar"
+				caption={date}
+				style={{
+					position: 'relative',
+					flex: '1 0 20%',
+					justifyContent: 'flex-end',
+					bottom: drop,
+					opacity,
+				}}
+			/>
+			<IconWithCaption
+				iconifyId="mdi:map-marker-radius-outline"
+				caption={location}
+				style={{
+					position: 'relative',
+					flex: '1 0 20%',
+					justifyContent: 'flex-start',
+					bottom: drop,
+					opacity,
+				}}
+			/>
+			{time && (
+				<IconWithCaption
+					iconifyId="mdi:clock"
+					caption={time}
+					style={{
+						position: 'relative',
+						flexBasis: '100%',
+						bottom: drop,
+						opacity,
+					}}
+				/>
+			)}
+		</div>
 	);
 };

--- a/remotion/compositions/showcases/alpescraft/Details.tsx
+++ b/remotion/compositions/showcases/alpescraft/Details.tsx
@@ -54,27 +54,14 @@ export const Details: React.FC<{
 					fontSize: 50,
 				}}
 			/>
-			<IconWithCaption
-				iconifyId="mdi:map-marker-radius-outline"
-				caption={location}
-				style={{
-					position: 'relative',
-					flex: '1 0 20%',
-					justifyContent: 'flex-start',
-					bottom: drop,
-					opacity,
-				}}
-				iconStyle={{
-					fontSize: 50,
-				}}
-			/>
 			{time && (
 				<IconWithCaption
 					iconifyId="mdi:clock"
 					caption={time}
 					style={{
 						position: 'relative',
-						flexBasis: '100%',
+						flex: '1 0 20%',
+						justifyContent: 'flex-start',
 						bottom: drop,
 						opacity,
 					}}
@@ -83,6 +70,19 @@ export const Details: React.FC<{
 					}}
 				/>
 			)}
+			<IconWithCaption
+				iconifyId="mdi:map-marker-radius-outline"
+				caption={location}
+				style={{
+					position: 'relative',
+					flexBasis: '100%',
+					bottom: drop,
+					opacity,
+				}}
+				iconStyle={{
+					fontSize: 50,
+				}}
+			/>
 		</div>
 	);
 };

--- a/remotion/compositions/showcases/alpescraft/Details.tsx
+++ b/remotion/compositions/showcases/alpescraft/Details.tsx
@@ -37,6 +37,7 @@ export const Details: React.FC<{
 				alignItems: 'center',
 				flexWrap: 'wrap',
 				columnGap: '7rem',
+				rowGap: '1.5rem',
 			}}
 		>
 			<IconWithCaption
@@ -49,6 +50,9 @@ export const Details: React.FC<{
 					bottom: drop,
 					opacity,
 				}}
+				iconStyle={{
+					fontSize: 50,
+				}}
 			/>
 			<IconWithCaption
 				iconifyId="mdi:map-marker-radius-outline"
@@ -60,6 +64,9 @@ export const Details: React.FC<{
 					bottom: drop,
 					opacity,
 				}}
+				iconStyle={{
+					fontSize: 50,
+				}}
 			/>
 			{time && (
 				<IconWithCaption
@@ -70,6 +77,9 @@ export const Details: React.FC<{
 						flexBasis: '100%',
 						bottom: drop,
 						opacity,
+					}}
+					iconStyle={{
+						fontSize: 45,
 					}}
 				/>
 			)}

--- a/remotion/compositions/showcases/devoxx2023/Details.tsx
+++ b/remotion/compositions/showcases/devoxx2023/Details.tsx
@@ -1,6 +1,7 @@
 import {spring, useCurrentFrame, useVideoConfig} from 'remotion';
 import {loadFont} from '@remotion/google-fonts/Aldrich';
 import {Icon} from '@iconify/react';
+import {IconWithCaption} from '../../../design/molecules/IconWithCaption';
 
 const {fontFamily} = loadFont();
 
@@ -60,8 +61,9 @@ export const Details: React.FC<{
 				});
 
 				return (
-					<div
-						key={`detail-${index}`}
+					<IconWithCaption
+						iconifyId={item.icon}
+						caption={item.data}
 						style={{
 							opacity,
 							position: 'relative',
@@ -71,15 +73,8 @@ export const Details: React.FC<{
 							gap: '1rem',
 							bottom: drop,
 						}}
-					>
-						<Icon
-							icon={item.icon}
-							style={{
-								fontSize: 40,
-							}}
-						/>
-						<span>{item.data}</span>
-					</div>
+						iconStyle={{fontSize: 40}}
+					/>
 				);
 			})}
 		</div>

--- a/remotion/compositions/showcases/devoxx2023/Details.tsx
+++ b/remotion/compositions/showcases/devoxx2023/Details.tsx
@@ -62,6 +62,7 @@ export const Details: React.FC<{
 
 				return (
 					<IconWithCaption
+						key={index}
 						iconifyId={item.icon}
 						caption={item.data}
 						style={{

--- a/remotion/compositions/showcases/lyonJS/Details.tsx
+++ b/remotion/compositions/showcases/lyonJS/Details.tsx
@@ -8,6 +8,7 @@ import {
 import {loadFont} from '@remotion/google-fonts/Aldrich';
 import {Icon} from '@iconify/react';
 import React from 'react';
+import {IconWithCaption} from '../../../design/molecules/IconWithCaption';
 
 const {fontFamily} = loadFont();
 
@@ -76,8 +77,9 @@ export const Details: React.FC<{
 				});
 
 				return (
-					<div
-						key={item.icon}
+					<IconWithCaption
+						iconifyId={item.icon}
+						caption={item.data}
 						style={{
 							opacity,
 							position: 'relative',
@@ -85,23 +87,11 @@ export const Details: React.FC<{
 							justifyContent: 'center',
 							alignItems: 'center',
 							gap: '1rem',
+							fontSize: 35,
 							bottom: drop,
 						}}
-					>
-						<Icon
-							icon={item.icon}
-							style={{
-								fontSize: 40,
-							}}
-						/>
-						<span
-							style={{
-								fontSize: 35,
-							}}
-						>
-							{item.data}
-						</span>
-					</div>
+						iconStyle={{fontSize: 40}}
+					/>
 				);
 			})}
 		</div>

--- a/remotion/compositions/showcases/lyonJS/Details.tsx
+++ b/remotion/compositions/showcases/lyonJS/Details.tsx
@@ -78,6 +78,7 @@ export const Details: React.FC<{
 
 				return (
 					<IconWithCaption
+						key={index}
 						iconifyId={item.icon}
 						caption={item.data}
 						style={{

--- a/remotion/compositions/showcases/mixit2023/Details.tsx
+++ b/remotion/compositions/showcases/mixit2023/Details.tsx
@@ -1,5 +1,3 @@
-import {Lottie} from '@remotion/lottie';
-import {useLottie} from '../../../hooks/useLottie';
 import {Sequence, spring, useCurrentFrame, useVideoConfig} from 'remotion';
 import {TalkDetails} from '../../../design/molecules/TalkDetails';
 
@@ -10,9 +8,6 @@ export const Details: React.FC<{
 }> = ({date, time, location}) => {
 	const frame = useCurrentFrame();
 	const {fps} = useVideoConfig();
-	const illustrationDate = useLottie('lf20_ak90tqhe');
-	const illustrationHour = useLottie('lf20_nv5aXa');
-	const illustrationLocation = useLottie('lf20_PgZU3O');
 
 	const drop = spring({
 		frame: frame - 40,
@@ -28,10 +23,6 @@ export const Details: React.FC<{
 		fps,
 		durationInFrames: 30,
 	});
-
-	if (!illustrationHour || !illustrationDate || !illustrationLocation) {
-		return null;
-	}
 
 	return (
 		<Sequence from={40} name="Details">

--- a/remotion/compositions/showcases/mixit2023/Details.tsx
+++ b/remotion/compositions/showcases/mixit2023/Details.tsx
@@ -1,6 +1,7 @@
 import {Lottie} from '@remotion/lottie';
 import {useLottie} from '../../../hooks/useLottie';
 import {Sequence, spring, useCurrentFrame, useVideoConfig} from 'remotion';
+import {TalkDetails} from '../../../design/molecules/TalkDetails';
 
 export const Details: React.FC<{
 	date: string;
@@ -13,8 +14,20 @@ export const Details: React.FC<{
 	const illustrationHour = useLottie('lf20_nv5aXa');
 	const illustrationLocation = useLottie('lf20_PgZU3O');
 
-	const drop = spring({frame, from: -20, to: 0, fps, durationInFrames: 30});
-	const opacity = spring({frame, from: 0, to: 1, fps, durationInFrames: 30});
+	const drop = spring({
+		frame: frame - 40,
+		from: -20,
+		to: 0,
+		fps,
+		durationInFrames: 30,
+	});
+	const opacity = spring({
+		frame: frame - 40,
+		from: 0,
+		to: 1,
+		fps,
+		durationInFrames: 30,
+	});
 
 	if (!illustrationHour || !illustrationDate || !illustrationLocation) {
 		return null;
@@ -22,97 +35,19 @@ export const Details: React.FC<{
 
 	return (
 		<Sequence from={40} name="Details">
-			<div
+			<TalkDetails
+				date={date}
+				time={time}
+				location={location}
 				style={{
 					fontFamily: 'Lato,Helvetica Neue,Helvetica,Roboto,Arial,sans-serif',
-					fontWeight: 700,
 					fontSize: '32px',
-					color: 'white',
-					position: 'absolute',
-					bottom: 0,
-					display: 'flex',
-					width: '100%',
-					justifyContent: 'space-around',
-					alignItems: 'center',
 				}}
-			>
-				<div
-					style={{
-						display: 'flex',
-						justifyContent: 'center',
-						alignItems: 'center',
-						gap: '1rem',
-					}}
-				>
-					<Lottie
-						style={{
-							width: '130px',
-							filter: 'none',
-						}}
-						playbackRate={1.5}
-						animationData={illustrationDate}
-					/>
-					<span
-						style={{
-							position: 'relative',
-							bottom: drop,
-							opacity,
-						}}
-					>
-						{date}
-					</span>
-				</div>
-				<div
-					style={{
-						display: 'flex',
-						justifyContent: 'center',
-						alignItems: 'center',
-						gap: '2rem',
-					}}
-				>
-					<Lottie
-						style={{
-							width: '70px',
-							filter: 'none',
-						}}
-						animationData={illustrationHour}
-					/>
-					<span
-						style={{
-							position: 'relative',
-							bottom: drop,
-							opacity,
-						}}
-					>
-						{time}
-					</span>
-				</div>
-				<div
-					style={{
-						display: 'flex',
-						justifyContent: 'center',
-						alignItems: 'center',
-						gap: '1rem',
-					}}
-				>
-					<Lottie
-						style={{
-							width: '80px',
-							filter: 'none',
-						}}
-						animationData={illustrationLocation}
-					/>
-					<span
-						style={{
-							position: 'relative',
-							bottom: drop,
-							opacity,
-						}}
-					>
-						{location}
-					</span>
-				</div>
-			</div>
+				iconStyle={{
+					opacity,
+					bottom: drop,
+				}}
+			/>
 		</Sequence>
 	);
 };

--- a/remotion/compositions/showcases/mixit2023/Details.tsx
+++ b/remotion/compositions/showcases/mixit2023/Details.tsx
@@ -27,9 +27,11 @@ export const Details: React.FC<{
 	return (
 		<Sequence from={40} name="Details">
 			<TalkDetails
-				date={date}
-				time={time}
-				location={location}
+				items={{
+					date,
+					time,
+					location,
+				}}
 				style={{
 					fontFamily: 'Lato,Helvetica Neue,Helvetica,Roboto,Arial,sans-serif',
 					fontSize: '32px',

--- a/remotion/compositions/showcases/snowcamp/Details.tsx
+++ b/remotion/compositions/showcases/snowcamp/Details.tsx
@@ -1,6 +1,7 @@
 import {Lottie} from '@remotion/lottie';
 import {useLottie} from '../../../hooks/useLottie';
 import {spring, useCurrentFrame, useVideoConfig} from 'remotion';
+import {TalkDetails} from '../../../design/molecules/TalkDetails';
 
 export const Details: React.FC<{
 	date: string;
@@ -9,108 +10,23 @@ export const Details: React.FC<{
 }> = ({date, time, location}) => {
 	const frame = useCurrentFrame();
 	const {fps} = useVideoConfig();
-	const illustrationDate = useLottie('lf20_ak90tqhe');
-	const illustrationHour = useLottie('lf20_nv5aXa');
-	const illustrationLocation = useLottie('lf20_PgZU3O');
 
 	const drop = spring({frame, from: -20, to: 0, fps, durationInFrames: 30});
 	const opacity = spring({frame, from: 0, to: 1, fps, durationInFrames: 30});
 
-	if (!illustrationHour || !illustrationDate || !illustrationLocation) {
-		return null;
-	}
-
 	return (
-		<div
+		<TalkDetails
+			date={date}
+			time={time}
+			location={location}
 			style={{
 				fontFamily: 'Noto Sans,sans-serif',
-				fontWeight: 700,
 				fontSize: '32px',
-				color: 'white',
-				position: 'absolute',
-				bottom: 0,
-				display: 'flex',
-				width: '100%',
-				justifyContent: 'space-around',
-				alignItems: 'center',
 			}}
-		>
-			<div
-				style={{
-					display: 'flex',
-					justifyContent: 'center',
-					alignItems: 'center',
-					gap: '1rem',
-				}}
-			>
-				<Lottie
-					style={{
-						width: '130px',
-						filter: 'none',
-					}}
-					playbackRate={1.5}
-					animationData={illustrationDate}
-				/>
-				<span
-					style={{
-						position: 'relative',
-						bottom: drop,
-						opacity,
-					}}
-				>
-					{date}
-				</span>
-			</div>
-			<div
-				style={{
-					display: 'flex',
-					justifyContent: 'center',
-					alignItems: 'center',
-					gap: '2rem',
-				}}
-			>
-				<Lottie
-					style={{
-						width: '70px',
-						filter: 'none',
-					}}
-					animationData={illustrationHour}
-				/>
-				<span
-					style={{
-						position: 'relative',
-						bottom: drop,
-						opacity,
-					}}
-				>
-					{time}
-				</span>
-			</div>
-			<div
-				style={{
-					display: 'flex',
-					justifyContent: 'center',
-					alignItems: 'center',
-					gap: '1rem',
-				}}
-			>
-				<Lottie
-					style={{
-						width: '80px',
-						filter: 'none',
-					}}
-					animationData={illustrationLocation}
-				/>
-				<span
-					style={{
-						position: 'relative',
-						bottom: drop,
-						opacity,
-					}}
-				>
-					{location}
-				</span>
-			</div>
-		</div>
+			iconStyle={{
+				opacity,
+				bottom: drop,
+			}}
+		/>
 	);
 };

--- a/remotion/compositions/showcases/snowcamp/Details.tsx
+++ b/remotion/compositions/showcases/snowcamp/Details.tsx
@@ -1,5 +1,3 @@
-import {Lottie} from '@remotion/lottie';
-import {useLottie} from '../../../hooks/useLottie';
 import {spring, useCurrentFrame, useVideoConfig} from 'remotion';
 import {TalkDetails} from '../../../design/molecules/TalkDetails';
 
@@ -16,9 +14,11 @@ export const Details: React.FC<{
 
 	return (
 		<TalkDetails
-			date={date}
-			time={time}
-			location={location}
+			items={{
+				date,
+				time,
+				location,
+			}}
 			style={{
 				fontFamily: 'Noto Sans,sans-serif',
 				fontSize: '32px',

--- a/remotion/compositions/showcases/touraineTech2023/Details.tsx
+++ b/remotion/compositions/showcases/touraineTech2023/Details.tsx
@@ -1,6 +1,7 @@
 import {Lottie} from '@remotion/lottie';
 import {useLottie} from '../../../hooks/useLottie';
 import {Sequence, spring, useCurrentFrame, useVideoConfig} from 'remotion';
+import {TalkDetails} from '../../../design/molecules/TalkDetails';
 
 export const Details: React.FC<{
 	date: string;
@@ -9,110 +10,37 @@ export const Details: React.FC<{
 }> = ({date, time, location}) => {
 	const frame = useCurrentFrame();
 	const {fps} = useVideoConfig();
-	const illustrationDate = useLottie('lf20_ak90tqhe');
-	const illustrationHour = useLottie('lf20_nv5aXa');
-	const illustrationLocation = useLottie('lf20_PgZU3O');
 
-	const drop = spring({frame, from: -20, to: 0, fps, durationInFrames: 30});
-	const opacity = spring({frame, from: 0, to: 1, fps, durationInFrames: 30});
-
-	if (!illustrationHour || !illustrationDate || !illustrationLocation) {
-		return null;
-	}
+	const drop = spring({
+		frame: frame - 40,
+		from: -20,
+		to: 0,
+		fps,
+		durationInFrames: 30,
+	});
+	const opacity = spring({
+		frame: frame - 40,
+		from: 0,
+		to: 1,
+		fps,
+		durationInFrames: 30,
+	});
 
 	return (
 		<Sequence from={40} name="Details">
-			<div
+			<TalkDetails
+				date={date}
+				time={time}
+				location={location}
 				style={{
 					fontFamily: 'Noto Sans,sans-serif',
-					fontWeight: 700,
 					fontSize: '32px',
-					color: 'white',
-					position: 'absolute',
-					bottom: 0,
-					display: 'flex',
-					width: '100%',
-					justifyContent: 'space-around',
-					alignItems: 'center',
 				}}
-			>
-				<div
-					style={{
-						display: 'flex',
-						justifyContent: 'center',
-						alignItems: 'center',
-						gap: '1rem',
-					}}
-				>
-					<Lottie
-						style={{
-							width: '130px',
-							filter: 'none',
-						}}
-						playbackRate={1.5}
-						animationData={illustrationDate}
-					/>
-					<span
-						style={{
-							position: 'relative',
-							bottom: drop,
-							opacity,
-						}}
-					>
-						{date}
-					</span>
-				</div>
-				<div
-					style={{
-						display: 'flex',
-						justifyContent: 'center',
-						alignItems: 'center',
-						gap: '2rem',
-					}}
-				>
-					<Lottie
-						style={{
-							width: '70px',
-							filter: 'none',
-						}}
-						animationData={illustrationHour}
-					/>
-					<span
-						style={{
-							position: 'relative',
-							bottom: drop,
-							opacity,
-						}}
-					>
-						{time}
-					</span>
-				</div>
-				<div
-					style={{
-						display: 'flex',
-						justifyContent: 'center',
-						alignItems: 'center',
-						gap: '1rem',
-					}}
-				>
-					<Lottie
-						style={{
-							width: '80px',
-							filter: 'none',
-						}}
-						animationData={illustrationLocation}
-					/>
-					<span
-						style={{
-							position: 'relative',
-							bottom: drop,
-							opacity,
-						}}
-					>
-						{location}
-					</span>
-				</div>
-			</div>
+				iconStyle={{
+					opacity,
+					bottom: drop,
+				}}
+			/>
 		</Sequence>
 	);
 };

--- a/remotion/compositions/showcases/touraineTech2023/Details.tsx
+++ b/remotion/compositions/showcases/touraineTech2023/Details.tsx
@@ -1,5 +1,3 @@
-import {Lottie} from '@remotion/lottie';
-import {useLottie} from '../../../hooks/useLottie';
 import {Sequence, spring, useCurrentFrame, useVideoConfig} from 'remotion';
 import {TalkDetails} from '../../../design/molecules/TalkDetails';
 
@@ -29,9 +27,11 @@ export const Details: React.FC<{
 	return (
 		<Sequence from={40} name="Details">
 			<TalkDetails
-				date={date}
-				time={time}
-				location={location}
+				items={{
+					date,
+					time,
+					location,
+				}}
 				style={{
 					fontFamily: 'Noto Sans,sans-serif',
 					fontSize: '32px',

--- a/remotion/compositions/showcases/touraineTech2023/Type.tsx
+++ b/remotion/compositions/showcases/touraineTech2023/Type.tsx
@@ -1,52 +1,23 @@
-import {Lottie} from '@remotion/lottie';
-import {useLottie} from '../../../hooks/useLottie';
 import {spring, useCurrentFrame, useVideoConfig} from 'remotion';
+import {TalkDetails} from '../../../design/molecules/TalkDetails';
+import React from 'react';
 
 export const Type: React.FC<{type: string}> = ({type}) => {
 	const frame = useCurrentFrame();
 	const {fps} = useVideoConfig();
-	const illustrationHour = useLottie('lf20_nv5aXa');
 
 	const drop = spring({frame, from: -20, to: 0, fps, durationInFrames: 30});
 	const opacity = spring({frame, from: 0, to: 1, fps, durationInFrames: 30});
 
-	if (!illustrationHour) {
-		return null;
-	}
-
 	return (
-		<div
+		<TalkDetails
+			time={type}
 			style={{
-				position: 'absolute',
-				bottom: 30,
-				left: 0,
-				right: 0,
-				display: 'flex',
-				justifyContent: 'center',
-				alignItems: 'center',
-				gap: '2rem',
-				fontFamily: 'Noto Sans,sans-serif',
-				fontWeight: 700,
 				fontSize: '32px',
-				color: 'white',
+				gridTemplateColumns: '1fr',
+				fontFamily: 'Noto Sans,sans-serif',
 			}}
-		>
-			<Lottie
-				style={{
-					width: '70px',
-					filter: 'none',
-				}}
-				animationData={illustrationHour}
-			/>
-			<span
-				style={{
-					position: 'relative',
-					bottom: drop,
-					opacity,
-				}}
-			>
-				{type}
-			</span>
-		</div>
+			iconStyle={{opacity, bottom: drop}}
+		/>
 	);
 };

--- a/remotion/compositions/showcases/touraineTech2023/Type.tsx
+++ b/remotion/compositions/showcases/touraineTech2023/Type.tsx
@@ -11,7 +11,9 @@ export const Type: React.FC<{type: string}> = ({type}) => {
 
 	return (
 		<TalkDetails
-			time={type}
+			items={{
+				time: type,
+			}}
 			style={{
 				fontSize: '32px',
 				gridTemplateColumns: '1fr',

--- a/remotion/compositions/showcases/very-tech-trip/Details.tsx
+++ b/remotion/compositions/showcases/very-tech-trip/Details.tsx
@@ -1,9 +1,8 @@
 import {spring} from 'remotion';
 import {useVideoConfig} from 'remotion';
 import {useCurrentFrame} from 'remotion';
-import {useLottie} from '../../../hooks/useLottie';
 import React, {CSSProperties} from 'react';
-import {Lottie} from '@remotion/lottie';
+import {TalkDetails} from '../../../design/molecules/TalkDetails';
 
 export const Details: React.FC<{style?: CSSProperties; time: string}> = ({
 	style,
@@ -11,50 +10,15 @@ export const Details: React.FC<{style?: CSSProperties; time: string}> = ({
 }) => {
 	const frame = useCurrentFrame();
 	const {fps} = useVideoConfig();
-	const illustrationHour = useLottie('lf20_nv5aXa');
-	const drop = spring({frame, from: -20, to: 0, fps, durationInFrames: 30});
+
+	const drop = spring({frame, from: -20, to: 10, fps, durationInFrames: 30});
 	const opacity = spring({frame, from: 0, to: 1, fps, durationInFrames: 30});
 
-	if (!illustrationHour) {
-		return null;
-	}
-
 	return (
-		<div
-			style={{
-				display: 'flex',
-				padding: '20px',
-				justifyContent: 'center',
-				fontSize: '24px',
-				...style,
-			}}
-		>
-			<div
-				style={{
-					display: 'flex',
-					justifyContent: 'center',
-					alignItems: 'center',
-					gap: '2rem',
-				}}
-			>
-				<Lottie
-					style={{
-						width: '42px',
-						filter: 'none',
-					}}
-					animationData={illustrationHour}
-				/>
-				<span
-					style={{
-						position: 'relative',
-						bottom: drop,
-						fontWeight: 700,
-						opacity,
-					}}
-				>
-					{time}
-				</span>
-			</div>
-		</div>
+		<TalkDetails
+			time={time}
+			style={{fontSize: '1.3rem', gridTemplateColumns: '1fr', ...style}}
+			iconStyle={{opacity, bottom: drop}}
+		/>
 	);
 };

--- a/remotion/compositions/showcases/very-tech-trip/Details.tsx
+++ b/remotion/compositions/showcases/very-tech-trip/Details.tsx
@@ -16,8 +16,10 @@ export const Details: React.FC<{style?: CSSProperties; time: string}> = ({
 
 	return (
 		<TalkDetails
-			time={time}
-			style={{fontSize: '1.3rem', gridTemplateColumns: '1fr', ...style}}
+			items={{
+				time,
+			}}
+			style={{fontSize: '1.3rem', ...style}}
 			iconStyle={{opacity, bottom: drop}}
 		/>
 	);


### PR DESCRIPTION
## 🤔 Why do you want to make those changes?

The molecule was created but on many compositions it wasn't used

## 🧑‍🔬 How did you make them?

i've updated the compositions with the molecules details and iconWithCaption

## 🧪 How to check them?

- You shouldn't see lottie icons anymore but instead it's iconify icons
