### PR TITLE
fix(showcase): AlpesCraft composition id

### DIFF
--- a/remotion/compositions/showcases/alpescraft/AlpesCraft.composition.tsx
+++ b/remotion/compositions/showcases/alpescraft/AlpesCraft.composition.tsx
@@ -7,7 +7,7 @@ export const AlpesCraftComposition: React.FC = () => {
 	return (
 		<Folder name="AlpesCraft-2023">
 			<Composition
-				id="Alpescraft"
+				id="AlpesCraft"
 				component={AlpesCraft}
 				durationInFrames={200}
 				fps={30}


### PR DESCRIPTION
Change AlpesCraft composition id from 'Alpescraft' to 'AlpesCraft'.

This case issue causes an error when copy pastes the pnpm command from the website:
```
An error occurred:
Error: Cannot find composition with ID "AlpesCraft". Available composition: Sponsor, SponsorWithoutLogo.....
```

## 🤔 Why do you want to make those changes?

<!--
Explain the context of your changes in order to let reviewer understand what explains them.
-->

## 🧑‍🔬 How did you make them?

<!--
List your intention of action by doing this PR
-->

## 🧪 How to check them?

<!--
Explain how reviewer could check that you did not break anything
-->
