### PR TITLE
feat(templates): create branded talk template

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
 		"@remotion/shapes": "3.3.87",
 		"@types/jest": "29.5.1",
 		"@vercel/analytics": "^1.0.0",
-		"date-fns": "^2.29.3",
+		"date-fns": "2.29.3",
 		"jest": "29.5.0",
 		"lottie-web": "5.11.0",
 		"next": "^13.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,7 +26,7 @@ dependencies:
     specifier: ^1.0.0
     version: 1.0.0(react@18.2.0)
   date-fns:
-    specifier: ^2.29.3
+    specifier: 2.29.3
     version: 2.29.3
   jest:
     specifier: 29.5.0
@@ -36,7 +36,7 @@ dependencies:
     version: 5.11.0
   next:
     specifier: ^13.2.4
-    version: 13.2.4(@babel/core@7.21.3)(react-dom@18.2.0)(react@18.2.0)
+    version: 13.2.4(react-dom@18.2.0)(react@18.2.0)
   node-fetch:
     specifier: ^3.3.0
     version: 3.3.0
@@ -4560,7 +4560,7 @@ packages:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
     dev: false
 
-  /next@13.2.4(@babel/core@7.21.3)(react-dom@18.2.0)(react@18.2.0):
+  /next@13.2.4(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-g1I30317cThkEpvzfXujf0O4wtaQHtDCLhlivwlTJ885Ld+eOgcz7r3TGQzeU+cSRoNHtD8tsJgzxVdYojFssw==}
     engines: {node: '>=14.6.0'}
     hasBin: true
@@ -4587,7 +4587,7 @@ packages:
       postcss: 8.4.14
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(@babel/core@7.21.3)(react@18.2.0)
+      styled-jsx: 5.1.1(react@18.2.0)
     optionalDependencies:
       '@next/swc-android-arm-eabi': 13.2.4
       '@next/swc-android-arm64': 13.2.4
@@ -5457,7 +5457,7 @@ packages:
       webpack: 5.76.1(esbuild@0.16.12)
     dev: false
 
-  /styled-jsx@5.1.1(@babel/core@7.21.3)(react@18.2.0):
+  /styled-jsx@5.1.1(react@18.2.0):
     resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
     engines: {node: '>= 12.0.0'}
     peerDependencies:
@@ -5470,7 +5470,6 @@ packages:
       babel-plugin-macros:
         optional: true
     dependencies:
-      '@babel/core': 7.21.3
       client-only: 0.0.1
       react: 18.2.0
     dev: false

--- a/remotion/compositions/templates/talk/Talks.composition.tsx
+++ b/remotion/compositions/templates/talk/Talks.composition.tsx
@@ -42,7 +42,7 @@ export const TalksComposition: React.FC = () => {
 					title: 'Certification “Google Cloud Architect”',
 					startingDate: new Date(2023, 3, 18, 13),
 					endingDate: new Date(2023, 4, 23, 13, 45),
-					day: 'mardi',
+					reccuringDay: 'mardi',
 					logoUrl:
 						'https://user-images.githubusercontent.com/72607059/233019842-047a34a4-77c1-4200-adc8-c70a6daf8f10.svg',
 					speaker: {

--- a/remotion/compositions/templates/talk/Talks.composition.tsx
+++ b/remotion/compositions/templates/talk/Talks.composition.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import {Composition, Folder, staticFile} from 'remotion';
 import {Talk} from './Talk';
+import {TalkBranded} from './branded/TalkBranded';
 
 export const TalksComposition: React.FC = () => {
 	return (
@@ -28,6 +29,31 @@ export const TalksComposition: React.FC = () => {
 				defaultProps={{
 					speakersNames: 'Foo bar',
 					talkTitle: 'Is JS an awesome programing language?',
+				}}
+			/>
+			<Composition
+				component={TalkBranded}
+				width={1200}
+				height={700}
+				id="TalkBranded"
+				fps={30}
+				durationInFrames={120}
+				defaultProps={{
+					title: 'Certification “Google Cloud Architect”',
+					startingDate: '18 Avril',
+					endingDate: '23 Mai',
+					startingTime: '13h',
+					endingTime: '13h45',
+					day: 'mardi',
+					logoUrl:
+						'https://user-images.githubusercontent.com/72607059/233019842-047a34a4-77c1-4200-adc8-c70a6daf8f10.svg',
+					host: {
+						pictureUrl:
+							'https://res.cloudinary.com/startup-grind/image/upload/c_fill,dpr_2.0,f_auto,g_center,h_250,q_auto:good,w_250/v1/gcs/platform-data-goog/events/20200911_094649_MbC4W4N.jpg',
+						name: 'Julien Landuré',
+						company: 'Zenika Nantes',
+						job: 'CTO / GDE',
+					},
 				}}
 			/>
 		</Folder>

--- a/remotion/compositions/templates/talk/Talks.composition.tsx
+++ b/remotion/compositions/templates/talk/Talks.composition.tsx
@@ -47,7 +47,7 @@ export const TalksComposition: React.FC = () => {
 					day: 'mardi',
 					logoUrl:
 						'https://user-images.githubusercontent.com/72607059/233019842-047a34a4-77c1-4200-adc8-c70a6daf8f10.svg',
-					host: {
+					speaker: {
 						pictureUrl:
 							'https://res.cloudinary.com/startup-grind/image/upload/c_fill,dpr_2.0,f_auto,g_center,h_250,q_auto:good,w_250/v1/gcs/platform-data-goog/events/20200911_094649_MbC4W4N.jpg',
 						name: 'Julien Landuré',

--- a/remotion/compositions/templates/talk/Talks.composition.tsx
+++ b/remotion/compositions/templates/talk/Talks.composition.tsx
@@ -43,7 +43,7 @@ export const TalksComposition: React.FC = () => {
 					startingDate: new Date(2023, 3, 18, 13),
 					endingDate: new Date(2023, 4, 23, 13, 45),
 					reccuringDay: 'mardi',
-					location: "8 Rue d'Algérie, 69001.",
+					location: '5 Place Jules Ferry, 69006.',
 					logoUrl:
 						'https://user-images.githubusercontent.com/72607059/233019842-047a34a4-77c1-4200-adc8-c70a6daf8f10.svg',
 					speaker: {

--- a/remotion/compositions/templates/talk/Talks.composition.tsx
+++ b/remotion/compositions/templates/talk/Talks.composition.tsx
@@ -40,10 +40,8 @@ export const TalksComposition: React.FC = () => {
 				durationInFrames={120}
 				defaultProps={{
 					title: 'Certification “Google Cloud Architect”',
-					startingDate: '18 Avril',
-					endingDate: '23 Mai',
-					startingTime: '13h',
-					endingTime: '13h45',
+					startingDate: new Date(2023, 3, 18, 13),
+					endingDate: new Date(2023, 4, 23, 13, 45),
 					day: 'mardi',
 					logoUrl:
 						'https://user-images.githubusercontent.com/72607059/233019842-047a34a4-77c1-4200-adc8-c70a6daf8f10.svg',

--- a/remotion/compositions/templates/talk/Talks.composition.tsx
+++ b/remotion/compositions/templates/talk/Talks.composition.tsx
@@ -37,12 +37,13 @@ export const TalksComposition: React.FC = () => {
 				height={700}
 				id="TalkBranded"
 				fps={30}
-				durationInFrames={120}
+				durationInFrames={140}
 				defaultProps={{
 					title: 'Certification “Google Cloud Architect”',
 					startingDate: new Date(2023, 3, 18, 13),
 					endingDate: new Date(2023, 4, 23, 13, 45),
 					reccuringDay: 'mardi',
+					location: "8 Rue d'Algérie, 69001.",
 					logoUrl:
 						'https://user-images.githubusercontent.com/72607059/233019842-047a34a4-77c1-4200-adc8-c70a6daf8f10.svg',
 					speaker: {

--- a/remotion/compositions/templates/talk/branded/BrandedDetails.tsx
+++ b/remotion/compositions/templates/talk/branded/BrandedDetails.tsx
@@ -31,7 +31,15 @@ export const BrandedDetails: React.FC<{
 	reccuringDay?: string;
 	startingTime: string;
 	endingTime?: string;
-}> = ({startingDate, endingDate, reccuringDay, startingTime, endingTime}) => {
+	location?: string;
+}> = ({
+	startingDate,
+	endingDate,
+	reccuringDay,
+	startingTime,
+	endingTime,
+	location,
+}) => {
 	const frame = useCurrentFrame();
 	const {fps} = useVideoConfig();
 
@@ -51,7 +59,7 @@ export const BrandedDetails: React.FC<{
 				justifyContent: 'center',
 				alignItems: 'flex-start',
 				height: 'max-content',
-				width: '100%',
+				width: location ? '50%' : '100%',
 				bottom: slideIn,
 			}}
 		>

--- a/remotion/compositions/templates/talk/branded/BrandedDetails.tsx
+++ b/remotion/compositions/templates/talk/branded/BrandedDetails.tsx
@@ -3,7 +3,7 @@ import {spring, useCurrentFrame, useVideoConfig} from 'remotion';
 import {Icon} from '@iconify/react';
 import {Text} from '../../../../design/atoms/Text';
 
-const Day: React.FC<{day: string}> = ({day}) => {
+const ReccuringDay: React.FC<{day: string}> = ({day}) => {
 	return (
 		<span>
 			Tout les <b>{day}</b>.{' '}
@@ -19,7 +19,7 @@ const TimeRange: React.FC<{
 		<span>
 			De{' '}
 			<b>
-				{startingTime} à {endingTime}
+				{startingTime} à {endingTime}.
 			</b>
 		</span>
 	);
@@ -28,10 +28,10 @@ const TimeRange: React.FC<{
 export const BrandedDetails: React.FC<{
 	startingDate: string;
 	endingDate?: string;
-	day?: string;
+	reccuringDay?: string;
 	startingTime: string;
 	endingTime?: string;
-}> = ({startingDate, endingDate, day, startingTime, endingTime}) => {
+}> = ({startingDate, endingDate, reccuringDay, startingTime, endingTime}) => {
 	const frame = useCurrentFrame();
 	const {fps} = useVideoConfig();
 
@@ -85,7 +85,7 @@ export const BrandedDetails: React.FC<{
 						fontSize: '1.18rem',
 					}}
 				>
-					{day && <Day day={day} />}
+					{reccuringDay && <ReccuringDay day={reccuringDay} />}
 					{endingTime ? (
 						<TimeRange startingTime={startingTime} endingTime={endingTime} />
 					) : (

--- a/remotion/compositions/templates/talk/branded/BrandedDetails.tsx
+++ b/remotion/compositions/templates/talk/branded/BrandedDetails.tsx
@@ -1,7 +1,29 @@
 import React from 'react';
-import {AbsoluteFill, spring, useCurrentFrame, useVideoConfig} from 'remotion';
+import {spring, useCurrentFrame, useVideoConfig} from 'remotion';
 import {Icon} from '@iconify/react';
 import {Text} from '../../../../design/atoms/Text';
+
+const Day: React.FC<{day: string}> = ({day}) => {
+	return (
+		<span>
+			Tout les <b>{day}</b>.{' '}
+		</span>
+	);
+};
+
+const TimeRange: React.FC<{
+	startingTime: string;
+	endingTime: string;
+}> = ({startingTime, endingTime}) => {
+	return (
+		<span>
+			De{' '}
+			<b>
+				{startingTime} à {endingTime}
+			</b>
+		</span>
+	);
+};
 
 export const BrandedDetails: React.FC<{
 	startingDate: string;
@@ -27,9 +49,8 @@ export const BrandedDetails: React.FC<{
 				position: 'absolute',
 				display: 'flex',
 				justifyContent: 'center',
-				alignItems: 'center',
+				alignItems: 'flex-start',
 				height: 'max-content',
-				fontSize: '1.6rem',
 				width: '100%',
 				bottom: slideIn,
 			}}
@@ -37,7 +58,7 @@ export const BrandedDetails: React.FC<{
 			<Icon
 				icon="mdi:calendar"
 				style={{
-					fontSize: '6rem',
+					fontSize: '4.5rem',
 					color: 'white',
 				}}
 			/>
@@ -48,9 +69,9 @@ export const BrandedDetails: React.FC<{
 						fontFamily: 'inherit',
 						display: 'block',
 						textAlign: 'left',
-						fontSize: '2.125rem',
+						fontSize: '1.7rem',
 						fontWeight: 'bold',
-						paddingBottom: '10px',
+						paddingBottom: '5px',
 					}}
 				>
 					{endingDate ? `Du ${startingDate} au ${endingDate}` : startingDate}
@@ -61,7 +82,7 @@ export const BrandedDetails: React.FC<{
 						fontFamily: 'inherit',
 						display: 'block',
 						textAlign: 'left',
-						fontSize: '1.5rem',
+						fontSize: '1.18rem',
 					}}
 				>
 					{day && <Day day={day} />}
@@ -73,27 +94,5 @@ export const BrandedDetails: React.FC<{
 				</Text>
 			</div>
 		</div>
-	);
-};
-
-const Day: React.FC<{day: string}> = ({day}) => {
-	return (
-		<span>
-			Tout les <b>{day}</b>.{' '}
-		</span>
-	);
-};
-
-const TimeRange: React.FC<{
-	startingTime: string;
-	endingTime: string;
-}> = ({startingTime, endingTime}) => {
-	return (
-		<span>
-			De{' '}
-			<b>
-				{startingTime} à {endingTime}
-			</b>
-		</span>
 	);
 };

--- a/remotion/compositions/templates/talk/branded/BrandedDetails.tsx
+++ b/remotion/compositions/templates/talk/branded/BrandedDetails.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import {AbsoluteFill, spring, useCurrentFrame, useVideoConfig} from 'remotion';
+import {Icon} from '@iconify/react';
+import {Text} from '../../../../design/atoms/Text';
+
+export const BrandedDetails: React.FC<{
+	startingDate: string;
+	endingDate?: string;
+	day?: string;
+	startingTime: string;
+	endingTime?: string;
+}> = ({startingDate, endingDate, day, startingTime, endingTime}) => {
+	const frame = useCurrentFrame();
+	const {fps} = useVideoConfig();
+
+	const slideIn = spring({
+		frame,
+		fps,
+		from: -100,
+		to: 50,
+		durationInFrames: 30,
+	});
+
+	return (
+		<div
+			style={{
+				position: 'absolute',
+				display: 'flex',
+				justifyContent: 'center',
+				alignItems: 'center',
+				height: 'max-content',
+				fontSize: '1.6rem',
+				width: '100%',
+				bottom: slideIn,
+			}}
+		>
+			<Icon
+				icon="mdi:calendar"
+				style={{
+					fontSize: '6rem',
+					color: 'white',
+				}}
+			/>
+			<div>
+				<Text
+					style={{
+						position: 'relative',
+						fontFamily: 'inherit',
+						display: 'block',
+						textAlign: 'left',
+						fontSize: '2.125rem',
+						fontWeight: 'bold',
+						paddingBottom: '10px',
+					}}
+				>
+					{endingDate ? `Du ${startingDate} au ${endingDate}` : startingDate}
+				</Text>
+				<Text
+					style={{
+						position: 'relative',
+						fontFamily: 'inherit',
+						display: 'block',
+						textAlign: 'left',
+						fontSize: '1.5rem',
+					}}
+				>
+					{day && <Day day={day} />}
+					{endingTime ? (
+						<TimeRange startingTime={startingTime} endingTime={endingTime} />
+					) : (
+						startingTime
+					)}
+				</Text>
+			</div>
+		</div>
+	);
+};
+
+const Day: React.FC<{day: string}> = ({day}) => {
+	return (
+		<span>
+			Tout les <b>{day}</b>.{' '}
+		</span>
+	);
+};
+
+const TimeRange: React.FC<{
+	startingTime: string;
+	endingTime: string;
+}> = ({startingTime, endingTime}) => {
+	return (
+		<span>
+			De{' '}
+			<b>
+				{startingTime} à {endingTime}
+			</b>
+		</span>
+	);
+};

--- a/remotion/compositions/templates/talk/branded/BrandedHost.tsx
+++ b/remotion/compositions/templates/talk/branded/BrandedHost.tsx
@@ -45,12 +45,6 @@ export const BrandedHost: React.FC<{
 		[50, 70, 60, 50, 70],
 	];
 
-	const blobAnimation = blobRadiuses.map((values) => {
-		return interpolate(frame, [10, 40, 70, 100, 140], values, {
-			extrapolateRight: 'clamp',
-		});
-	});
-
 	const [
 		blobRadius1,
 		blobRadius2,
@@ -58,7 +52,11 @@ export const BrandedHost: React.FC<{
 		blobRadius4,
 		blobRadius5,
 		blobRadius6,
-	] = blobAnimation;
+	] = blobRadiuses.map((values) => {
+		return interpolate(frame, [10, 40, 70, 100, 140], values, {
+			extrapolateRight: 'clamp',
+		});
+	});
 
 	const textStyles = {
 		opacity,

--- a/remotion/compositions/templates/talk/branded/BrandedHost.tsx
+++ b/remotion/compositions/templates/talk/branded/BrandedHost.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import {AvatarWithCaption} from '../../../../design/molecules/AvatarWithCaption';
+import {Text} from '../../../../design/atoms/Text';
+import {
+	AbsoluteFill,
+	interpolate,
+	spring,
+	useCurrentFrame,
+	useVideoConfig,
+} from 'remotion';
+
+export const BrandedHost: React.FC<{
+	pictureUrl: string;
+	name: string;
+	company?: string;
+	job?: string;
+}> = ({pictureUrl, name, company, job}) => {
+	const frame = useCurrentFrame();
+	const {fps} = useVideoConfig();
+
+	const slideIn = spring({
+		frame,
+		fps,
+		from: -300,
+		to: 0,
+		durationInFrames: 30,
+	});
+	const opacity = spring({
+		frame: frame - 10,
+		fps,
+		from: 0,
+		to: 1,
+		durationInFrames: 30,
+	});
+	const unblur = interpolate(frame, [10, 30], [5, 0], {
+		extrapolateRight: 'clamp',
+	});
+
+	const blobRadiuses = [
+		[40, 70, 100, 40, 70],
+		[60, 30, 60, 60, 30],
+		[70, 50, 60, 70, 50],
+		[30, 50, 100, 30, 50],
+		[40, 30, 100, 40, 30],
+		[50, 70, 60, 50, 70],
+	];
+
+	const blobAnimation = blobRadiuses.map((values) => {
+		return interpolate(frame, [10, 40, 70, 100, 140], values, {
+			extrapolateRight: 'clamp',
+		});
+	});
+
+	const [
+		blobRadius1,
+		blobRadius2,
+		blobRadius3,
+		blobRadius4,
+		blobRadius5,
+		blobRadius6,
+	] = blobAnimation;
+
+	return (
+		<AbsoluteFill style={{left: 500, top: 70}}>
+			<AvatarWithCaption
+				avatarPictureUrl={pictureUrl}
+				avatarStyle={{
+					width: 200,
+					height: 200,
+					border: 'none',
+					borderRadius: `${blobRadius1}% ${blobRadius2}% ${blobRadius3}% ${blobRadius4}% / ${blobRadius5}% ${blobRadius5}% ${blobRadius2}% ${blobRadius6}%`,
+					boxShadow: '20px 20px 0 white',
+				}}
+				style={{
+					position: 'relative',
+					flexDirection: 'row',
+					gap: 60,
+					top: slideIn,
+				}}
+			>
+				<div
+					style={{
+						display: 'flex',
+						flexDirection: 'column',
+					}}
+				>
+					<Text
+						style={{
+							opacity,
+							width: 'auto',
+							fontSize: '2.75rem',
+							fontWeight: 'bold',
+							fontFamily: 'inherit',
+							textShadow: '1px 1px 15px #000000bb',
+							filter: `blur(${unblur}px)`,
+						}}
+					>
+						{name}
+					</Text>
+					<hr
+						style={{
+							opacity,
+							background: 'white',
+							width: 50,
+							height: 4,
+							marginLeft: 20,
+							marginTop: 20,
+							border: 'none',
+							filter: `blur(${unblur}px)`,
+						}}
+					/>
+					<Text
+						style={{
+							opacity,
+							width: 'auto',
+							textAlign: 'left',
+							fontFamily: 'inherit',
+							fontSize: '1.5rem',
+							marginBottom: '10px',
+							textShadow: '1px 1px 15px #000000bb',
+							filter: `blur(${unblur}px)`,
+						}}
+					>
+						{company}
+					</Text>
+					<Text
+						style={{
+							opacity,
+							width: 'auto',
+							textAlign: 'left',
+							fontFamily: 'inherit',
+							fontSize: '1.25rem',
+							textShadow: '1px 1px 15px #000000bb',
+							filter: `blur(${unblur}px)`,
+						}}
+					>
+						{job}
+					</Text>
+				</div>
+			</AvatarWithCaption>
+		</AbsoluteFill>
+	);
+};

--- a/remotion/compositions/templates/talk/branded/BrandedHost.tsx
+++ b/remotion/compositions/templates/talk/branded/BrandedHost.tsx
@@ -60,6 +60,13 @@ export const BrandedHost: React.FC<{
 		blobRadius6,
 	] = blobAnimation;
 
+	const textStyles = {
+		opacity,
+		fontFamily: 'inherit',
+		textShadow: '1px 1px 15px #000000bb',
+		filter: `blur(${unblur}px)`,
+	};
+
 	return (
 		<AbsoluteFill style={{left: 500, top: 70}}>
 			<AvatarWithCaption
@@ -86,52 +93,42 @@ export const BrandedHost: React.FC<{
 				>
 					<Text
 						style={{
-							opacity,
+							...textStyles,
 							width: 'auto',
 							fontSize: '2.75rem',
 							fontWeight: 'bold',
-							fontFamily: 'inherit',
-							textShadow: '1px 1px 15px #000000bb',
-							filter: `blur(${unblur}px)`,
 						}}
 					>
 						{name}
 					</Text>
 					<hr
 						style={{
-							opacity,
+							...textStyles,
 							background: 'white',
 							width: 50,
 							height: 4,
 							marginLeft: 20,
 							marginTop: 20,
 							border: 'none',
-							filter: `blur(${unblur}px)`,
 						}}
 					/>
 					<Text
 						style={{
-							opacity,
+							...textStyles,
 							width: 'auto',
 							textAlign: 'left',
-							fontFamily: 'inherit',
 							fontSize: '1.5rem',
 							marginBottom: '10px',
-							textShadow: '1px 1px 15px #000000bb',
-							filter: `blur(${unblur}px)`,
 						}}
 					>
 						{company}
 					</Text>
 					<Text
 						style={{
-							opacity,
+							...textStyles,
 							width: 'auto',
 							textAlign: 'left',
-							fontFamily: 'inherit',
 							fontSize: '1.25rem',
-							textShadow: '1px 1px 15px #000000bb',
-							filter: `blur(${unblur}px)`,
 						}}
 					>
 						{job}

--- a/remotion/compositions/templates/talk/branded/BrandedLocation.tsx
+++ b/remotion/compositions/templates/talk/branded/BrandedLocation.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import {spring, useCurrentFrame, useVideoConfig} from 'remotion';
+import {Icon} from '@iconify/react';
+import {Text} from '../../../../design/atoms/Text';
+
+export const BrandedLocation: React.FC<{
+	location: string;
+}> = ({location}) => {
+	const frame = useCurrentFrame();
+	const {fps} = useVideoConfig();
+
+	const slideIn = spring({
+		frame,
+		fps,
+		from: -100,
+		to: 50,
+		durationInFrames: 30,
+	});
+
+	return (
+		<div
+			style={{
+				position: 'absolute',
+				display: 'flex',
+				justifyContent: 'center',
+				alignItems: 'center',
+				height: 'max-content',
+				width: '50%',
+				right: 0,
+				bottom: slideIn,
+			}}
+		>
+			<Icon
+				icon="material-symbols:location-on-rounded"
+				style={{
+					fontSize: '4.5rem',
+					color: 'white',
+				}}
+			/>
+			<Text
+				style={{
+					position: 'relative',
+					fontFamily: 'inherit',
+					display: 'block',
+					textAlign: 'left',
+					fontSize: '1.7rem',
+					fontWeight: 'bold',
+					paddingBottom: '5px',
+					width: 'auto',
+				}}
+			>
+				{location}
+			</Text>
+		</div>
+	);
+};

--- a/remotion/compositions/templates/talk/branded/BrandedLocation.tsx
+++ b/remotion/compositions/templates/talk/branded/BrandedLocation.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {spring, useCurrentFrame, useVideoConfig} from 'remotion';
 import {Icon} from '@iconify/react';
 import {Text} from '../../../../design/atoms/Text';
+import {IconWithCaption} from '../../../../design/molecules/IconWithCaption';
 
 export const BrandedLocation: React.FC<{
 	location: string;
@@ -18,39 +19,22 @@ export const BrandedLocation: React.FC<{
 	});
 
 	return (
-		<div
+		<IconWithCaption
+			iconifyId="material-symbols:location-on-rounded"
+			caption={location}
 			style={{
 				position: 'absolute',
-				display: 'flex',
-				justifyContent: 'center',
-				alignItems: 'center',
 				height: 'max-content',
 				width: '50%',
 				right: 0,
+				color: 'white',
+				fontWeight: 'bold',
 				bottom: slideIn,
 			}}
-		>
-			<Icon
-				icon="material-symbols:location-on-rounded"
-				style={{
-					fontSize: '4.5rem',
-					color: 'white',
-				}}
-			/>
-			<Text
-				style={{
-					position: 'relative',
-					fontFamily: 'inherit',
-					display: 'block',
-					textAlign: 'left',
-					fontSize: '1.7rem',
-					fontWeight: 'bold',
-					paddingBottom: '5px',
-					width: 'auto',
-				}}
-			>
-				{location}
-			</Text>
-		</div>
+			iconStyle={{
+				fontSize: '4.5rem',
+				color: 'white',
+			}}
+		/>
 	);
 };

--- a/remotion/compositions/templates/talk/branded/BrandedLogo.tsx
+++ b/remotion/compositions/templates/talk/branded/BrandedLogo.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import {
+	AbsoluteFill,
+	Img,
+	spring,
+	useCurrentFrame,
+	useVideoConfig,
+} from 'remotion';
+
+export const BrandedLogo: React.FC<{
+	logoUrl: string;
+	borderColor?: string;
+}> = ({logoUrl, borderColor = '#EA4335'}) => {
+	const frame = useCurrentFrame();
+	const {fps} = useVideoConfig();
+
+	const slideInTop = spring({
+		frame,
+		fps,
+		from: -500,
+		to: -100,
+		durationInFrames: 30,
+	});
+
+	const slideIn = spring({
+		frame,
+		fps,
+		from: -500,
+		to: -75,
+		durationInFrames: 30,
+	});
+
+	return (
+		<AbsoluteFill
+			style={{
+				background: 'white',
+				width: '450px',
+				height: '450px',
+				justifyContent: 'center',
+				alignItems: 'center',
+				borderRadius: '50%',
+				border: `10px solid ${borderColor}`,
+				boxShadow: '0 0 0 10px white',
+				top: slideInTop,
+				left: slideIn,
+			}}
+		>
+			<Img src={logoUrl} width={250} />
+		</AbsoluteFill>
+	);
+};

--- a/remotion/compositions/templates/talk/branded/BrandedSpeaker.tsx
+++ b/remotion/compositions/templates/talk/branded/BrandedSpeaker.tsx
@@ -8,6 +8,7 @@ import {
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
+import {IconWithCaption} from '../../../../design/molecules/IconWithCaption';
 
 export const BrandedSpeaker: React.FC<{
 	pictureUrl: string;
@@ -109,27 +110,34 @@ export const BrandedSpeaker: React.FC<{
 							border: 'none',
 						}}
 					/>
-					<Text
-						style={{
-							...textStyles,
-							width: 'auto',
-							textAlign: 'left',
-							fontSize: '1.5rem',
-							marginBottom: '10px',
-						}}
-					>
-						{company}
-					</Text>
-					<Text
-						style={{
-							...textStyles,
-							width: 'auto',
-							textAlign: 'left',
-							fontSize: '1.25rem',
-						}}
-					>
-						{job}
-					</Text>
+					{company && (
+						<IconWithCaption
+							style={{
+								...textStyles,
+								justifyContent: 'flex-start',
+								fontSize: '1.5rem',
+								color: 'white',
+								paddingLeft: 15,
+							}}
+							caption={company}
+							iconifyId="mdi:company"
+							iconStyle={{width: 40}}
+						/>
+					)}
+					{job && (
+						<IconWithCaption
+							style={{
+								...textStyles,
+								justifyContent: 'flex-start',
+								fontSize: '1.25rem',
+								color: 'white',
+								paddingLeft: 15,
+							}}
+							caption={job}
+							iconifyId="mdi:user"
+							iconStyle={{width: 40, height: 40}}
+						/>
+					)}
 				</div>
 			</AvatarWithCaption>
 		</AbsoluteFill>

--- a/remotion/compositions/templates/talk/branded/BrandedSpeaker.tsx
+++ b/remotion/compositions/templates/talk/branded/BrandedSpeaker.tsx
@@ -27,12 +27,12 @@ export const BrandedSpeaker: React.FC<{
 	});
 
 	const blobRadiuses = [
-		[40, 70, 100, 40, 70],
-		[60, 30, 60, 60, 30],
-		[70, 50, 60, 70, 50],
-		[30, 50, 100, 30, 50],
-		[40, 30, 100, 40, 30],
-		[50, 70, 60, 50, 70],
+		[40, 70],
+		[60, 30],
+		[70, 50],
+		[30, 50],
+		[40, 30],
+		[50, 70],
 	];
 
 	const [
@@ -43,7 +43,7 @@ export const BrandedSpeaker: React.FC<{
 		blobRadius5,
 		blobRadius6,
 	] = blobRadiuses.map((values) => {
-		return interpolate(frame, [10, 130, 170, 200, 230], values, {
+		return interpolate(frame, [10, 130], values, {
 			extrapolateRight: 'clamp',
 		});
 	});

--- a/remotion/compositions/templates/talk/branded/BrandedSpeaker.tsx
+++ b/remotion/compositions/templates/talk/branded/BrandedSpeaker.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {AvatarWithCaption} from '../../../../design/molecules/AvatarWithCaption';
-import {Text} from '../../../../design/atoms/Text';
 import {
 	AbsoluteFill,
 	interpolate,
@@ -8,7 +7,7 @@ import {
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
-import {IconWithCaption} from '../../../../design/molecules/IconWithCaption';
+import {BrandedSpeakerInfos} from './BrandedSpeakerInfos';
 
 export const BrandedSpeaker: React.FC<{
 	pictureUrl: string;
@@ -25,16 +24,6 @@ export const BrandedSpeaker: React.FC<{
 		from: -300,
 		to: 0,
 		durationInFrames: 30,
-	});
-	const opacity = spring({
-		frame: frame - 10,
-		fps,
-		from: 0,
-		to: 1,
-		durationInFrames: 30,
-	});
-	const unblur = interpolate(frame, [10, 30], [5, 0], {
-		extrapolateRight: 'clamp',
 	});
 
 	const blobRadiuses = [
@@ -59,12 +48,6 @@ export const BrandedSpeaker: React.FC<{
 		});
 	});
 
-	const textStyles = {
-		opacity,
-		fontFamily: 'inherit',
-		filter: `blur(${unblur}px)`,
-	};
-
 	return (
 		<AbsoluteFill style={{left: 500, top: 70}}>
 			<AvatarWithCaption
@@ -83,62 +66,7 @@ export const BrandedSpeaker: React.FC<{
 					top: slideIn,
 				}}
 			>
-				<div
-					style={{
-						display: 'flex',
-						flexDirection: 'column',
-					}}
-				>
-					<Text
-						style={{
-							...textStyles,
-							width: 'auto',
-							fontSize: '2.75rem',
-							fontWeight: 'bold',
-						}}
-					>
-						{name}
-					</Text>
-					<hr
-						style={{
-							...textStyles,
-							background: 'white',
-							width: 50,
-							height: 4,
-							marginLeft: 20,
-							marginTop: 20,
-							border: 'none',
-						}}
-					/>
-					{company && (
-						<IconWithCaption
-							style={{
-								...textStyles,
-								justifyContent: 'flex-start',
-								fontSize: '1.5rem',
-								color: 'white',
-								paddingLeft: 15,
-							}}
-							caption={company}
-							iconifyId="mdi:company"
-							iconStyle={{width: 40}}
-						/>
-					)}
-					{job && (
-						<IconWithCaption
-							style={{
-								...textStyles,
-								justifyContent: 'flex-start',
-								fontSize: '1.25rem',
-								color: 'white',
-								paddingLeft: 15,
-							}}
-							caption={job}
-							iconifyId="mdi:user"
-							iconStyle={{width: 40, height: 40}}
-						/>
-					)}
-				</div>
+				<BrandedSpeakerInfos name={name} company={company} job={job} />
 			</AvatarWithCaption>
 		</AbsoluteFill>
 	);

--- a/remotion/compositions/templates/talk/branded/BrandedSpeaker.tsx
+++ b/remotion/compositions/templates/talk/branded/BrandedSpeaker.tsx
@@ -9,7 +9,7 @@ import {
 	useVideoConfig,
 } from 'remotion';
 
-export const BrandedHost: React.FC<{
+export const BrandedSpeaker: React.FC<{
 	pictureUrl: string;
 	name: string;
 	company?: string;
@@ -53,7 +53,7 @@ export const BrandedHost: React.FC<{
 		blobRadius5,
 		blobRadius6,
 	] = blobRadiuses.map((values) => {
-		return interpolate(frame, [10, 40, 70, 100, 140], values, {
+		return interpolate(frame, [10, 130, 170, 200, 230], values, {
 			extrapolateRight: 'clamp',
 		});
 	});
@@ -61,7 +61,6 @@ export const BrandedHost: React.FC<{
 	const textStyles = {
 		opacity,
 		fontFamily: 'inherit',
-		textShadow: '1px 1px 15px #000000bb',
 		filter: `blur(${unblur}px)`,
 	};
 

--- a/remotion/compositions/templates/talk/branded/BrandedSpeakerInfos.tsx
+++ b/remotion/compositions/templates/talk/branded/BrandedSpeakerInfos.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import {Text} from '../../../../design/atoms/Text';
+import {IconWithCaption} from '../../../../design/molecules/IconWithCaption';
+import {interpolate, spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
+export const BrandedSpeakerInfos: React.FC<{
+	name: string;
+	company?: string;
+	job?: string;
+}> = ({name, company, job}) => {
+	const frame = useCurrentFrame();
+	const {fps} = useVideoConfig();
+	const opacity = spring({
+		frame: frame - 10,
+		fps,
+		from: 0,
+		to: 1,
+		durationInFrames: 30,
+	});
+	const unblur = interpolate(frame, [10, 30], [5, 0], {
+		extrapolateRight: 'clamp',
+	});
+
+	const textStyles = {
+		opacity,
+		fontFamily: 'inherit',
+		filter: `blur(${unblur}px)`,
+	};
+
+	return (
+		<div
+			style={{
+				display: 'flex',
+				flexDirection: 'column',
+			}}
+		>
+			<Text
+				style={{
+					...textStyles,
+					width: 'auto',
+					fontSize: '2.75rem',
+					fontWeight: 'bold',
+				}}
+			>
+				{name}
+			</Text>
+			<hr
+				style={{
+					...textStyles,
+					background: 'white',
+					width: 50,
+					height: 4,
+					marginLeft: 20,
+					marginTop: 20,
+					border: 'none',
+				}}
+			/>
+			{company && (
+				<IconWithCaption
+					style={{
+						...textStyles,
+						justifyContent: 'flex-start',
+						fontSize: '1.5rem',
+						color: 'white',
+						paddingLeft: 15,
+					}}
+					caption={company}
+					iconifyId="mdi:company"
+					iconStyle={{width: 35}}
+				/>
+			)}
+			{job && (
+				<IconWithCaption
+					style={{
+						...textStyles,
+						justifyContent: 'flex-start',
+						fontSize: '1.25rem',
+						color: 'white',
+						paddingLeft: 15,
+					}}
+					caption={job}
+					iconifyId="mdi:user"
+					iconStyle={{width: 35, height: 35}}
+				/>
+			)}
+		</div>
+	);
+};

--- a/remotion/compositions/templates/talk/branded/BrandedTitle.tsx
+++ b/remotion/compositions/templates/talk/branded/BrandedTitle.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import {Title} from '../../../../design/atoms/Title';
+import {
+	AbsoluteFill,
+	interpolate,
+	spring,
+	useCurrentFrame,
+	useVideoConfig,
+} from 'remotion';
+
+export const BrandedTitle: React.FC<{title: string}> = ({title}) => {
+	const frame = useCurrentFrame();
+	const {fps} = useVideoConfig();
+
+	const titleOpacity = spring({
+		frame,
+		fps,
+		from: 0,
+		to: 1,
+		durationInFrames: 60,
+	});
+	const titleUnblur = interpolate(frame, [0, 20], [5, 0], {
+		extrapolateRight: 'clamp',
+	});
+	return (
+		<AbsoluteFill style={{top: 400}}>
+			<Title
+				style={{
+					fontFamily: 'inherit',
+					fontSize: '3.25rem',
+					width: '100%',
+					opacity: titleOpacity,
+					filter: `blur(${titleUnblur}px)`,
+				}}
+			>
+				{title}
+			</Title>
+		</AbsoluteFill>
+	);
+};

--- a/remotion/compositions/templates/talk/branded/BrandedTitle.tsx
+++ b/remotion/compositions/templates/talk/branded/BrandedTitle.tsx
@@ -23,7 +23,7 @@ export const BrandedTitle: React.FC<{title: string}> = ({title}) => {
 		extrapolateRight: 'clamp',
 	});
 	return (
-		<AbsoluteFill style={{top: 400}}>
+		<AbsoluteFill style={{top: 380}}>
 			<Title
 				style={{
 					fontFamily: 'inherit',

--- a/remotion/compositions/templates/talk/branded/TalkBranded.tsx
+++ b/remotion/compositions/templates/talk/branded/TalkBranded.tsx
@@ -8,6 +8,7 @@ import {BrandedLogo} from './BrandedLogo';
 import {BrandedSpeaker} from './BrandedSpeaker';
 import {format} from 'date-fns';
 import {fr} from 'date-fns/locale';
+import {BrandedLocation} from './BrandedLocation';
 
 const {fontFamily} = loadFont();
 
@@ -17,6 +18,7 @@ export const TalkBranded: React.FC<{
 	startingDate: Date;
 	endingDate?: Date;
 	reccuringDay?: string;
+	location?: string;
 	logoUrl: string;
 	speaker: {pictureUrl: string; name: string; company?: string; job?: string};
 }> = ({
@@ -25,6 +27,7 @@ export const TalkBranded: React.FC<{
 	startingDate,
 	endingDate,
 	reccuringDay,
+	location,
 	logoUrl,
 	speaker,
 }) => {
@@ -64,8 +67,14 @@ export const TalkBranded: React.FC<{
 					reccuringDay={reccuringDay}
 					startingTime={startingTime}
 					endingTime={endingTime}
+					location={location}
 				/>
 			</Sequence>
+			{location && (
+				<Sequence name="Location" from={55}>
+					<BrandedLocation location={location} />
+				</Sequence>
+			)}
 		</AbsoluteFill>
 	);
 };

--- a/remotion/compositions/templates/talk/branded/TalkBranded.tsx
+++ b/remotion/compositions/templates/talk/branded/TalkBranded.tsx
@@ -6,17 +6,17 @@ import {BrandedDetails} from './BrandedDetails';
 import {BackgroundCircleNoise} from '../../../../design/atoms/BackgroundCircleNoise';
 import {BrandedLogo} from './BrandedLogo';
 import {BrandedSpeaker} from './BrandedSpeaker';
+import {format} from 'date-fns';
+import {fr} from 'date-fns/locale';
 
 const {fontFamily} = loadFont();
 
 export const TalkBranded: React.FC<{
 	backgroundColor?: string;
 	title: string;
-	startingDate: string;
-	endingDate?: string;
+	startingDate: Date;
+	endingDate?: Date;
 	day?: string;
-	startingTime: string;
-	endingTime?: string;
 	logoUrl: string;
 	speaker: {pictureUrl: string; name: string; company?: string; job?: string};
 }> = ({
@@ -25,11 +25,13 @@ export const TalkBranded: React.FC<{
 	startingDate,
 	endingDate,
 	day,
-	startingTime,
-	endingTime,
 	logoUrl,
 	speaker,
 }) => {
+	const startingDay = format(startingDate, 'dd MMMM', {locale: fr});
+	const endingDay = endingDate && format(endingDate, 'dd MMMM', {locale: fr});
+	const startingTime = format(startingDate, 'HH:mm');
+	const endingTime = endingDate && format(endingDate, 'HH:mm');
 	return (
 		<AbsoluteFill
 			style={{
@@ -56,8 +58,8 @@ export const TalkBranded: React.FC<{
 			</Sequence>
 			<Sequence name="Details" from={50}>
 				<BrandedDetails
-					startingDate={startingDate}
-					endingDate={endingDate}
+					startingDate={startingDay}
+					endingDate={endingDay}
 					day={day}
 					startingTime={startingTime}
 					endingTime={endingTime}

--- a/remotion/compositions/templates/talk/branded/TalkBranded.tsx
+++ b/remotion/compositions/templates/talk/branded/TalkBranded.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import {AbsoluteFill, Sequence} from 'remotion';
+import {loadFont} from '@remotion/google-fonts/OpenSans';
+import {BrandedTitle} from './BrandedTitle';
+import {BrandedDetails} from './BrandedDetails';
+import {BackgroundCircleNoise} from '../../../../design/atoms/BackgroundCircleNoise';
+import {BrandedLogo} from './BrandedLogo';
+import {BrandedHost} from './BrandedHost';
+
+const {fontFamily} = loadFont();
+
+export const TalkBranded: React.FC<{
+	backgroundColor?: string;
+	title: string;
+	startingDate: string;
+	endingDate?: string;
+	day?: string;
+	startingTime: string;
+	endingTime?: string;
+	logoUrl: string;
+	host: {pictureUrl: string; name: string; company?: string; job?: string};
+}> = ({
+	backgroundColor = '#EA4335',
+	title,
+	startingDate,
+	endingDate,
+	day,
+	startingTime,
+	endingTime,
+	logoUrl,
+	host,
+}) => {
+	return (
+		<AbsoluteFill
+			style={{
+				backgroundColor,
+				fontFamily,
+			}}
+		>
+			<Sequence name="Noise Background">
+				<BackgroundCircleNoise speed={0.01} circleRadius={5} maxOffset={20} />
+			</Sequence>
+			<Sequence name="Logo">
+				<BrandedLogo logoUrl={logoUrl} borderColor={backgroundColor} />
+			</Sequence>
+			<Sequence name="Host" from={10}>
+				<BrandedHost
+					pictureUrl={host.pictureUrl}
+					name={host.name}
+					company={host.company}
+					job={host.job}
+				/>
+			</Sequence>
+			<Sequence name="Title" from={40}>
+				<BrandedTitle title={title} />
+			</Sequence>
+			<Sequence name="Details" from={50}>
+				<BrandedDetails
+					startingDate={startingDate}
+					endingDate={endingDate}
+					day={day}
+					startingTime={startingTime}
+					endingTime={endingTime}
+				/>
+			</Sequence>
+		</AbsoluteFill>
+	);
+};

--- a/remotion/compositions/templates/talk/branded/TalkBranded.tsx
+++ b/remotion/compositions/templates/talk/branded/TalkBranded.tsx
@@ -16,7 +16,7 @@ export const TalkBranded: React.FC<{
 	title: string;
 	startingDate: Date;
 	endingDate?: Date;
-	day?: string;
+	reccuringDay?: string;
 	logoUrl: string;
 	speaker: {pictureUrl: string; name: string; company?: string; job?: string};
 }> = ({
@@ -24,7 +24,7 @@ export const TalkBranded: React.FC<{
 	title,
 	startingDate,
 	endingDate,
-	day,
+	reccuringDay,
 	logoUrl,
 	speaker,
 }) => {
@@ -32,6 +32,7 @@ export const TalkBranded: React.FC<{
 	const endingDay = endingDate && format(endingDate, 'dd MMMM', {locale: fr});
 	const startingTime = format(startingDate, 'HH:mm');
 	const endingTime = endingDate && format(endingDate, 'HH:mm');
+
 	return (
 		<AbsoluteFill
 			style={{
@@ -60,7 +61,7 @@ export const TalkBranded: React.FC<{
 				<BrandedDetails
 					startingDate={startingDay}
 					endingDate={endingDay}
-					day={day}
+					reccuringDay={reccuringDay}
 					startingTime={startingTime}
 					endingTime={endingTime}
 				/>

--- a/remotion/compositions/templates/talk/branded/TalkBranded.tsx
+++ b/remotion/compositions/templates/talk/branded/TalkBranded.tsx
@@ -5,7 +5,7 @@ import {BrandedTitle} from './BrandedTitle';
 import {BrandedDetails} from './BrandedDetails';
 import {BackgroundCircleNoise} from '../../../../design/atoms/BackgroundCircleNoise';
 import {BrandedLogo} from './BrandedLogo';
-import {BrandedHost} from './BrandedHost';
+import {BrandedSpeaker} from './BrandedSpeaker';
 
 const {fontFamily} = loadFont();
 
@@ -18,7 +18,7 @@ export const TalkBranded: React.FC<{
 	startingTime: string;
 	endingTime?: string;
 	logoUrl: string;
-	host: {pictureUrl: string; name: string; company?: string; job?: string};
+	speaker: {pictureUrl: string; name: string; company?: string; job?: string};
 }> = ({
 	backgroundColor = '#EA4335',
 	title,
@@ -28,7 +28,7 @@ export const TalkBranded: React.FC<{
 	startingTime,
 	endingTime,
 	logoUrl,
-	host,
+	speaker,
 }) => {
 	return (
 		<AbsoluteFill
@@ -43,12 +43,12 @@ export const TalkBranded: React.FC<{
 			<Sequence name="Logo">
 				<BrandedLogo logoUrl={logoUrl} borderColor={backgroundColor} />
 			</Sequence>
-			<Sequence name="Host" from={10}>
-				<BrandedHost
-					pictureUrl={host.pictureUrl}
-					name={host.name}
-					company={host.company}
-					job={host.job}
+			<Sequence name="Speaker" from={10}>
+				<BrandedSpeaker
+					pictureUrl={speaker.pictureUrl}
+					name={speaker.name}
+					company={speaker.company}
+					job={speaker.job}
 				/>
 			</Sequence>
 			<Sequence name="Title" from={40}>


### PR DESCRIPTION
## 🤔 Why do you want to make those changes?

New template for talk with custom logo, speaker and color with. Customised with the GDG design by default, see the discussion about it here #219 .

## 🧑‍🔬 How did you make them?

I created the compositions and it's different elements animated

## 🧪 How to check them?

- You can check the video on the remotion preview under `Templates/Talk/TalkBranded`
