### PR TITLE
feat(app): add showcase camping des speakers

### DIFF
--- a/app/showcases/conferences/[conferenceName]/page.tsx
+++ b/app/showcases/conferences/[conferenceName]/page.tsx
@@ -70,8 +70,8 @@ const Template: Record<string, TalkTemplate> = {
 	CampingDesSpeakers: {
 		compositionName: 'CampingDesSpeakers',
 		component: CampingDesSpeakers,
-		width: 1200,
-		height: 700,
+		width: 1280,
+		height: 720,
 		durationInFrames: 450,
 		fps: 60,
 		defaultProps: _.merge(

--- a/app/showcases/conferences/[conferenceName]/page.tsx
+++ b/app/showcases/conferences/[conferenceName]/page.tsx
@@ -12,13 +12,16 @@ import {useState} from 'react';
 import {defaultTalkValues} from '../../../../src/data/defaultValues';
 import {AlpesCraft} from '../../../../remotion/compositions/showcases/alpescraft/AlpesCraft';
 import {Code} from '../../../../src/app/Code';
-
+import {CampingDesSpeakers} from '../../../../remotion/compositions/showcases/camping-des-speakers/CampingDesSpeakers';
+import _ = require('lodash');
 interface TalkTemplate {
 	component: React.FC<any>;
 	width: number;
 	height: number;
 	compositionName: string;
 	durationInFrames: number;
+	fps?: number;
+	defaultProps?: {};
 }
 
 const Template: Record<string, TalkTemplate> = {
@@ -64,6 +67,20 @@ const Template: Record<string, TalkTemplate> = {
 		height: 720,
 		durationInFrames: 200,
 	},
+	CampingDesSpeakers: {
+		compositionName: 'CampingDesSpeakers',
+		component: CampingDesSpeakers,
+		width: 1200,
+		height: 700,
+		durationInFrames: 450,
+		fps: 60,
+		defaultProps: _.merge(
+			{
+				speakers: [{company: 'Zenika'}, {company: 'Bedrock'}],
+			},
+			defaultTalkValues
+		),
+	},
 };
 export default function ConferencePage({
 	params,
@@ -72,7 +89,9 @@ export default function ConferencePage({
 }) {
 	const conference = params.conferenceName;
 	const currentTemplate = Template[conference];
-	const [data, setData] = useState(defaultTalkValues);
+	const [data, setData] = useState(
+		currentTemplate.defaultProps || defaultTalkValues
+	);
 
 	return (
 		<div>
@@ -105,12 +124,12 @@ export default function ConferencePage({
 					durationInFrames={currentTemplate.durationInFrames}
 					compositionWidth={currentTemplate.width}
 					compositionHeight={currentTemplate.height}
-					fps={30}
+					fps={currentTemplate.fps || 30}
 					component={currentTemplate.component}
 					inputProps={data || defaultTalkValues}
 				/>
 				<JSONInput
-					placeholder={defaultTalkValues}
+					placeholder={currentTemplate.defaultProps || defaultTalkValues}
 					theme="light_mitsuketa_tribute"
 					locale={locale}
 					colors={{

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"@testing-library/dom": "9.3.0",
 		"@testing-library/jest-dom": "5.16.5",
 		"@testing-library/react": "14.0.0",
-		"@types/lodash": "^4.14.194",
+		"@types/lodash": "4.14.194",
 		"@types/node": "18.16.7",
 		"@types/react": "18.2.6",
 		"@types/react-dom": "18.2.4",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
 		"@testing-library/dom": "9.3.0",
 		"@testing-library/jest-dom": "5.16.5",
 		"@testing-library/react": "14.0.0",
+		"@types/lodash": "^4.14.194",
 		"@types/node": "18.16.7",
 		"@types/react": "18.2.6",
 		"@types/react-dom": "18.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,7 +70,7 @@ devDependencies:
     specifier: 14.0.0
     version: 14.0.0(react-dom@18.2.0)(react@18.2.0)
   '@types/lodash':
-    specifier: ^4.14.194
+    specifier: 4.14.194
     version: 4.14.194
   '@types/node':
     specifier: 18.16.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,7 +36,7 @@ dependencies:
     version: 5.11.0
   next:
     specifier: ^13.2.4
-    version: 13.2.4(@babel/core@7.21.3)(react-dom@18.2.0)(react@18.2.0)
+    version: 13.2.4(react-dom@18.2.0)(react@18.2.0)
   node-fetch:
     specifier: ^3.3.0
     version: 3.3.0
@@ -69,6 +69,9 @@ devDependencies:
   '@testing-library/react':
     specifier: 14.0.0
     version: 14.0.0(react-dom@18.2.0)(react@18.2.0)
+  '@types/lodash':
+    specifier: ^4.14.194
+    version: 4.14.194
   '@types/node':
     specifier: 18.16.7
     version: 18.16.7
@@ -1551,6 +1554,10 @@ packages:
 
   /@types/json5@0.0.29:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+    dev: true
+
+  /@types/lodash@4.14.194:
+    resolution: {integrity: sha512-r22s9tAS7imvBt2lyHC9B8AGwWnXaYb1tY09oyLkXDs4vArpYJzw09nj8MLx5VfciBPGIb+ZwG0ssYnEPJxn/g==}
     dev: true
 
   /@types/minimatch@3.0.5:
@@ -4573,7 +4580,7 @@ packages:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
     dev: false
 
-  /next@13.2.4(@babel/core@7.21.3)(react-dom@18.2.0)(react@18.2.0):
+  /next@13.2.4(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-g1I30317cThkEpvzfXujf0O4wtaQHtDCLhlivwlTJ885Ld+eOgcz7r3TGQzeU+cSRoNHtD8tsJgzxVdYojFssw==}
     engines: {node: '>=14.6.0'}
     hasBin: true
@@ -4600,7 +4607,7 @@ packages:
       postcss: 8.4.14
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-      styled-jsx: 5.1.1(@babel/core@7.21.3)(react@18.2.0)
+      styled-jsx: 5.1.1(react@18.2.0)
     optionalDependencies:
       '@next/swc-android-arm-eabi': 13.2.4
       '@next/swc-android-arm64': 13.2.4
@@ -5470,7 +5477,7 @@ packages:
       webpack: 5.76.1(esbuild@0.16.12)
     dev: false
 
-  /styled-jsx@5.1.1(@babel/core@7.21.3)(react@18.2.0):
+  /styled-jsx@5.1.1(react@18.2.0):
     resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
     engines: {node: '>= 12.0.0'}
     peerDependencies:
@@ -5483,7 +5490,6 @@ packages:
       babel-plugin-macros:
         optional: true
     dependencies:
-      '@babel/core': 7.21.3
       client-only: 0.0.1
       react: 18.2.0
     dev: false

--- a/src/app/NavBar.tsx
+++ b/src/app/NavBar.tsx
@@ -29,7 +29,7 @@ export const NavBar: React.FC = () => {
 						<span>🎉 Event</span>
 					</li>
 				</ActiveLink>
-				<ActiveLink href="/showcases/conferences/Mixit">
+				<ActiveLink href="/showcases/conferences/CampingDesSpeakers">
 					<li className="text-black text-center mt-2 md:mt-0 md:ml-5 py-2 px-4 bg-white rounded-lg cursor-pointer font-bold shadow-yellow-300 hover:scale-105">
 						<span>🫱🏼‍🫲🏽 Conference</span>
 					</li>


### PR DESCRIPTION
## 🤔 Why do you want to make those changes?

We want to add the new created showcase for `Camping Des Speakers` to the app.

## 🧑‍🔬 How did you make them?

I added the showcase to the configuration and add some update for the fps and the defaultProps that are different in the new one.

## 🧪 How to check them?

- You can check on the preview if everything is ok, you should see the showcase and on it's props it should have the company. 
- Be sure that the company is on the command line, the video and on the json preview but only in this showcase.
