### PR TITLE
fix(webapp): copy url with date not working

### DIFF
--- a/app/templates/brandedTalk/page.tsx
+++ b/app/templates/brandedTalk/page.tsx
@@ -13,7 +13,6 @@ import {TalkBranded} from '../../../remotion/compositions/templates/talk/branded
 import {SelectInput} from '../../../src/app/forms/selectInput';
 import {ColorInput} from '../../../src/app/forms/colorInput';
 import {InputDate} from '../../../src/app/forms/inputDate';
-import {format} from 'date-fns';
 
 export default function BrandedTalkPage() {
 	const [backgroundColor, setBackgroundColor] = useInputChange<string>(
@@ -81,8 +80,8 @@ export default function BrandedTalkPage() {
 	const encodedParams = encodeObjectValues({
 		backgroundColor,
 		title,
-		startingDate: format(startingDate, 'yyyy-MM-dd HH:mm'),
-		endingDate: endingDate && format(endingDate, 'yyyy-MM-dd HH:mm'),
+		startingDate,
+		endingDate,
 		recurringDay,
 		location,
 		logoUrl,

--- a/app/templates/brandedTalk/page.tsx
+++ b/app/templates/brandedTalk/page.tsx
@@ -13,6 +13,7 @@ import {TalkBranded} from '../../../remotion/compositions/templates/talk/branded
 import {SelectInput} from '../../../src/app/forms/selectInput';
 import {ColorInput} from '../../../src/app/forms/colorInput';
 import {InputDate} from '../../../src/app/forms/inputDate';
+import {format} from 'date-fns';
 
 export default function BrandedTalkPage() {
 	const [backgroundColor, setBackgroundColor] = useInputChange<string>(
@@ -80,8 +81,8 @@ export default function BrandedTalkPage() {
 	const encodedParams = encodeObjectValues({
 		backgroundColor,
 		title,
-		startingDate,
-		endingDate,
+		startingDate: format(startingDate, 'yyyy-MM-dd HH:mm'),
+		endingDate: endingDate && format(endingDate, 'yyyy-MM-dd HH:mm'),
 		recurringDay,
 		location,
 		logoUrl,
@@ -128,6 +129,7 @@ export default function BrandedTalkPage() {
 						setValue={setSpeakerPicture}
 						value={speakerPicture}
 						label="Speaker picture"
+						placeholder="e.g: https://avatars.githubusercontent.com/u/929689?s=200&v=4"
 					/>
 					<Input
 						setValue={setSpeakersNames}

--- a/src/app/hooks/onInputChange.ts
+++ b/src/app/hooks/onInputChange.ts
@@ -29,7 +29,11 @@ export const useInputDateChange = <ValueType extends Date | undefined>(
 		? searchParams.get(query) ?? defaultValue
 		: defaultValue;
 
-	const [value, setValue] = useState<ValueType>(initialValue as ValueType);
+	const formatedInitialValue = initialValue && new Date(initialValue);
+
+	const [value, setValue] = useState<ValueType>(
+		formatedInitialValue as ValueType
+	);
 	const onValueChange = useCallback(
 		(event: FormEvent<HTMLInputElement | HTMLSelectElement>) => {
 			const newValue = new Date(event.currentTarget.value);


### PR DESCRIPTION
## 🤔 Why do you want to make those changes?

To fix the copy url button on the new branded talk page

## 🧑‍🔬 How did you make them?

The page couldn’t be saved because of the date that was in a wrong format so i've handle the formatting on the encoded object and on the recuperation of the query param

## 🧪 How to check them?

on the preview try to copy/paste the url with params
