### PR TITLE
feat(app): add volcamp video to showcases

### DIFF
--- a/app/showcases/conferences/[conferenceName]/page.tsx
+++ b/app/showcases/conferences/[conferenceName]/page.tsx
@@ -19,6 +19,7 @@ import {CampingDesSpeakers} from '../../../../remotion/compositions/showcases/ca
 import _ = require('lodash');
 import {ReplayProps} from '../../../templates/replay/page';
 import {TalkBrandedProps} from '../../../../remotion/compositions/templates/talk/branded/TalkBranded';
+import {Volcamp} from '../../../../remotion/compositions/showcases/volcamp/Volcamp';
 interface TalkTemplate {
 	component: React.FC<any>;
 	width: number;
@@ -86,6 +87,26 @@ const Template: Record<string, TalkTemplate> = {
 		defaultProps: _.merge(
 			{
 				speakers: [{company: 'Zenika'}, {company: 'Bedrock'}],
+			},
+			defaultTalkValues
+		),
+	},
+	Volcamp2023: {
+		compositionName: 'Volcamp2023',
+		component: Volcamp,
+		width: 1280,
+		height: 720,
+		durationInFrames: 300,
+		defaultProps: _.merge(
+			{
+				themeName: 'Web & Mobile',
+				speakers: [
+					{company: 'https://zenika.com/static/images/favicon-32x32.png'},
+					{
+						company:
+							'https://bedrockstreaming.com/assets/favicon/apple-icon-57x57.png',
+					},
+				],
 			},
 			defaultTalkValues
 		),

--- a/src/app/NavBar.tsx
+++ b/src/app/NavBar.tsx
@@ -34,7 +34,7 @@ export const NavBar: React.FC = () => {
 						<span>🎉 Event</span>
 					</li>
 				</ActiveLink>
-				<ActiveLink href="/showcases/conferences/CampingDesSpeakers">
+				<ActiveLink href="/showcases/conferences/Volcamp2023">
 					<li className="text-color-btn-text text-center mt-2 md:mt-0 md:ml-5 py-2 px-4 rounded-lg cursor-pointer font-bold hover:scale-105">
 						<span>🫱🏼‍🫲🏽 Conference</span>
 					</li>


### PR DESCRIPTION
## 🤔 Why do you want to make those changes?

After creating the showcase video, we add it in the app to make it available for the users to generate their own videos.

## 🧑‍🔬 How did you make them?

I've add the config of the Volcamp video to the `shocases/[conferenceName]/page.tsx` page and updated the navLink to make it point to this video in first.

## 🧪 How to check them?

- Check the video on the preview
- Check the code
