### PR TITLE
feat(types): refacto types

### DIFF
--- a/app/showcases/conferences/[conferenceName]/page.tsx
+++ b/app/showcases/conferences/[conferenceName]/page.tsx
@@ -1,9 +1,6 @@
 'use client';
 
-import {
-	Snowcamp,
-	TouraineTechProps,
-} from '../../../../remotion/compositions/showcases/snowcamp/Snowcamp';
+import {Snowcamp} from '../../../../remotion/compositions/showcases/snowcamp/Snowcamp';
 import {Devoxx2023} from '../../../../remotion/compositions/showcases/devoxx/Devoxx2023';
 import {MixitIntroTalk} from '../../../../remotion/compositions/showcases/mixit/MixitIntroTalk';
 import {TouraineTech2023} from '../../../../remotion/compositions/showcases/touraineTech/TouraineTech2023';
@@ -20,6 +17,7 @@ import _ = require('lodash');
 import {ReplayProps} from '../../../templates/replay/page';
 import {TalkBrandedProps} from '../../../../remotion/compositions/templates/talk/branded/TalkBranded';
 import {Volcamp} from '../../../../remotion/compositions/showcases/volcamp/Volcamp';
+import {DefaultProps} from '../../../../remotion/types/defaultProps.types';
 interface TalkTemplate {
 	component: React.FC<any>;
 	width: number;
@@ -29,7 +27,7 @@ interface TalkTemplate {
 	fps?: number;
 	defaultProps?:
 		| {[key: string]: string | undefined}
-		| TouraineTechProps
+		| DefaultProps
 		| ReplayProps
 		| TalkBrandedProps;
 }

--- a/app/templates/replay/page.tsx
+++ b/app/templates/replay/page.tsx
@@ -6,8 +6,8 @@ import {Code} from '../../../src/app/Code';
 
 import locale from 'react-json-editor-ajrm/locale/en';
 import JSONInput from 'react-json-editor-ajrm/index';
-import {Speaker} from '../../../remotion/compositions/showcases/snowcamp/Snowcamp';
 import {ReplayLyonJS} from '../../../remotion/compositions/showcases/lyonJS/Replay';
+import {Speaker} from '../../../remotion/types/defaultProps.types';
 
 export interface ReplayProps {
 	title: string;

--- a/remotion/compositions/showcases/alpescraft/AlpesCraft.tsx
+++ b/remotion/compositions/showcases/alpescraft/AlpesCraft.tsx
@@ -6,11 +6,7 @@ import {Mountains} from './Mountains';
 import {Logo} from './Logo';
 import {Speakers} from './Speakers';
 import {TalkBackground} from './TalkBackground';
-
-export interface Speaker {
-	picture: string;
-	name: string;
-}
+import {Speaker} from '../../../types/defaultProps.types';
 
 export interface AlpesCraftProps {
 	title: string;

--- a/remotion/compositions/showcases/alpescraft/Speakers.tsx
+++ b/remotion/compositions/showcases/alpescraft/Speakers.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Speaker} from '../../../types/conferences.types';
+import {Speaker} from '../../../types/defaultProps.types';
 import {SpeakersName} from './SpeakersName';
 import {AvatarWithCaption} from '../../../design/molecules/AvatarWithCaption';
 import {

--- a/remotion/compositions/showcases/devoxx/Devoxx2023.tsx
+++ b/remotion/compositions/showcases/devoxx/Devoxx2023.tsx
@@ -7,7 +7,7 @@ import {
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
-import {Talk} from '../../../types/conferences.types';
+import {DefaultProps} from '../../../types/defaultProps.types';
 import {Logo} from './Logo';
 import {Speakers} from './Speakers';
 import {TalkTitle} from './TalkTitle';
@@ -15,7 +15,7 @@ import React from 'react';
 import {Details} from './Details';
 import Balloons from './Balloons';
 
-export const Devoxx2023: React.FC<Talk> = ({
+export const Devoxx2023: React.FC<DefaultProps> = ({
 	title,
 	speakers,
 	date,

--- a/remotion/compositions/showcases/devoxx/Speakers.tsx
+++ b/remotion/compositions/showcases/devoxx/Speakers.tsx
@@ -1,6 +1,6 @@
 import {AbsoluteFill, spring, useCurrentFrame, useVideoConfig} from 'remotion';
 import {SpeakerName} from './SpeakerName';
-import {Speaker} from '../../../types/conferences.types';
+import {Speaker} from '../../../types/defaultProps.types';
 import {AvatarWithCaption} from '../../../design/molecules/AvatarWithCaption';
 
 export const Speakers: React.FC<{speakers: Speaker[]}> = ({speakers}) => {

--- a/remotion/compositions/showcases/lyonJS/BigSpeakers.tsx
+++ b/remotion/compositions/showcases/lyonJS/BigSpeakers.tsx
@@ -6,9 +6,9 @@ import {
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
-import {Speaker} from './Replay';
 import {AvatarWithCaption} from '../../../design/molecules/AvatarWithCaption';
 import {Text} from '../../../design/atoms/Text';
+import {Speaker} from '../../../types/defaultProps.types';
 
 export const BigSpeakers: React.FC<{speakers: Speaker[]; dropTop: number}> = ({
 	speakers,

--- a/remotion/compositions/showcases/lyonJS/Replay.tsx
+++ b/remotion/compositions/showcases/lyonJS/Replay.tsx
@@ -7,11 +7,7 @@ import React from 'react';
 import {Details} from './Details';
 import {LogoSponsor} from './LogoSponsor';
 import {BackgroundTriangle} from '../../../design/atoms/BackgroundTriangle';
-
-export interface Speaker {
-	picture: string;
-	name: string;
-}
+import {Speaker} from '../../../types/defaultProps.types';
 
 interface LyonJSReplayType {
 	title: string;

--- a/remotion/compositions/showcases/mixit/Mixit2023.tsx
+++ b/remotion/compositions/showcases/mixit/Mixit2023.tsx
@@ -3,10 +3,10 @@ import {LyonSkyline} from './LyonSkyline';
 import {Logo} from './Logo';
 import {Speakers} from './Speakers';
 import {Details} from './Details';
-import {Talk} from '../../../types/conferences.types';
+import {DefaultProps} from '../../../types/defaultProps.types';
 import {TalkTitle} from './TalkTitle';
 
-export const Mixit2023: React.FC<Talk> = ({
+export const Mixit2023: React.FC<DefaultProps> = ({
 	title,
 	speakers,
 	date,

--- a/remotion/compositions/showcases/mixit/MixitIntroTalk.tsx
+++ b/remotion/compositions/showcases/mixit/MixitIntroTalk.tsx
@@ -1,9 +1,9 @@
 import {AbsoluteFill} from 'remotion';
 import {MixitIntro} from './MixitIntro';
-import {Talk} from '../../../types/conferences.types';
+import {DefaultProps} from '../../../types/defaultProps.types';
 import {Mixit2023} from './Mixit2023';
 
-export const MixitIntroTalk: React.FC<Talk> = ({
+export const MixitIntroTalk: React.FC<DefaultProps> = ({
 	title,
 	speakers,
 	date,

--- a/remotion/compositions/showcases/mixit/Speakers.tsx
+++ b/remotion/compositions/showcases/mixit/Speakers.tsx
@@ -6,7 +6,7 @@ import {
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
-import {Speaker} from '../../../types/conferences.types';
+import {Speaker} from '../../../types/defaultProps.types';
 import {AvatarWithCaption} from '../../../design/molecules/AvatarWithCaption';
 import {Text} from '../../../design/atoms/Text';
 

--- a/remotion/compositions/showcases/snowcamp/Snowcamp.tsx
+++ b/remotion/compositions/showcases/snowcamp/Snowcamp.tsx
@@ -6,21 +6,9 @@ import React from 'react';
 import {Snow} from './Snow';
 import {Logo} from './Logo';
 import {TalkBackground} from './TalkBackground';
+import {DefaultProps} from '../../../types/defaultProps.types';
 
-export interface Speaker {
-	picture: string;
-	name: string;
-}
-
-export interface TouraineTechProps {
-	title: string;
-	speakers: Speaker[];
-	date: string;
-	time: string;
-	location: string;
-}
-
-export const Snowcamp: React.FC<TouraineTechProps> = ({
+export const Snowcamp: React.FC<DefaultProps> = ({
 	title,
 	speakers,
 	date,

--- a/remotion/compositions/showcases/snowcamp/Speakers.tsx
+++ b/remotion/compositions/showcases/snowcamp/Speakers.tsx
@@ -5,9 +5,9 @@ import {
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
-import {Speaker} from './Snowcamp';
 import {AvatarWithCaption} from '../../../design/molecules/AvatarWithCaption';
 import {Text} from '../../../design/atoms/Text';
+import {Speaker} from '../../../types/defaultProps.types';
 
 export const Speakers: React.FC<{speakers: Speaker[]}> = ({speakers}) => {
 	const frame = useCurrentFrame();

--- a/remotion/compositions/showcases/touraineTech/BigSpeakers.tsx
+++ b/remotion/compositions/showcases/touraineTech/BigSpeakers.tsx
@@ -6,9 +6,9 @@ import {
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
-import {Speaker} from './TouraineTech2023';
 import {AvatarWithCaption} from '../../../design/molecules/AvatarWithCaption';
 import {Text} from '../../../design/atoms/Text';
+import {Speaker} from '../../../types/defaultProps.types';
 
 export const BigSpeakers: React.FC<{speakers: Speaker[]; dropTop: number}> = ({
 	speakers,

--- a/remotion/compositions/showcases/touraineTech/Replay.tsx
+++ b/remotion/compositions/showcases/touraineTech/Replay.tsx
@@ -2,10 +2,10 @@ import {Sequence} from 'remotion';
 import {Logo} from './Logo';
 import {TalkTitle} from './TalkTitle';
 import {AbsoluteFill} from 'remotion';
-import {Speaker} from './TouraineTech2023';
 import {Type} from './Type';
 import {BigSpeakers} from './BigSpeakers';
 import {BackgroundTriangle} from '../../../design/atoms/BackgroundTriangle';
+import {Speaker} from '../../../types/defaultProps.types';
 
 interface ReplayType {
 	title: string;

--- a/remotion/compositions/showcases/touraineTech/Speakers.tsx
+++ b/remotion/compositions/showcases/touraineTech/Speakers.tsx
@@ -6,9 +6,9 @@ import {
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
-import {Speaker} from './TouraineTech2023';
 import {AvatarWithCaption} from '../../../design/molecules/AvatarWithCaption';
 import {Text} from '../../../design/atoms/Text';
+import {Speaker} from '../../../types/defaultProps.types';
 
 export const Speakers: React.FC<{speakers: Speaker[]}> = ({speakers}) => {
 	const frame = useCurrentFrame();

--- a/remotion/compositions/showcases/touraineTech/TouraineTech2023.tsx
+++ b/remotion/compositions/showcases/touraineTech/TouraineTech2023.tsx
@@ -5,21 +5,9 @@ import {TalkTitle} from './TalkTitle';
 import {Details} from './Details';
 import {Speakers} from './Speakers';
 import {BackgroundTriangle} from '../../../design/atoms/BackgroundTriangle';
+import {DefaultProps} from '../../../types/defaultProps.types';
 
-export interface Speaker {
-	picture: string;
-	name: string;
-}
-
-export interface TouraineTechProps {
-	title: string;
-	speakers: Speaker[];
-	date: string;
-	time: string;
-	location: string;
-}
-
-export const TouraineTech2023: React.FC<TouraineTechProps> = ({
+export const TouraineTech2023: React.FC<DefaultProps> = ({
 	title,
 	speakers,
 	date,

--- a/remotion/compositions/showcases/veryTechTrip/Speakers.tsx
+++ b/remotion/compositions/showcases/veryTechTrip/Speakers.tsx
@@ -1,5 +1,5 @@
 import {Sequence} from 'remotion';
-import {Speaker as SpeakerType} from '../../../types/conferences.types';
+import {Speaker as SpeakerType} from '../../../types/defaultProps.types';
 import React from 'react';
 import {FadeIn} from './FadeIn';
 import {AvatarWithCaption} from '../../../design/molecules/AvatarWithCaption';

--- a/remotion/compositions/showcases/veryTechTrip/VeryTechTrip.tsx
+++ b/remotion/compositions/showcases/veryTechTrip/VeryTechTrip.tsx
@@ -8,9 +8,13 @@ import {Speakers} from './Speakers';
 import {TalkTitle} from './TalkTitle';
 import {Details} from './Details';
 import {Logo} from './Logo';
-import {Talk} from '../../../types/conferences.types';
+import {DefaultProps} from '../../../types/defaultProps.types';
 
-export const VeryTechTrip: React.FC<Talk> = ({title, speakers, time}) => {
+export const VeryTechTrip: React.FC<DefaultProps> = ({
+	title,
+	speakers,
+	time,
+}) => {
 	const frame = useCurrentFrame();
 	const {fps} = useVideoConfig();
 

--- a/remotion/compositions/showcases/volcamp/components/Talk.tsx
+++ b/remotion/compositions/showcases/volcamp/components/Talk.tsx
@@ -1,4 +1,3 @@
-import {Sequence} from 'remotion';
 import {TalkTitle} from './TalkTitle';
 import {Details} from './Details';
 import {Theme, ThemeProps} from './Theme';

--- a/remotion/compositions/templates/layers/LayerFullScreen.tsx
+++ b/remotion/compositions/templates/layers/LayerFullScreen.tsx
@@ -2,6 +2,7 @@ import {AbsoluteFill, Img} from 'remotion';
 import React from 'react';
 import {GreenScreen} from '../../showcases/lyonJS/GreenScreen';
 import {BackgroundTriangle} from '../../../design/atoms/BackgroundTriangle';
+import {LayerBaseProps} from './layers.types';
 
 export const LayerFullScreen: React.FC<LayerBaseProps> = ({
 	primaryColor,

--- a/remotion/compositions/templates/layers/LayerOneSpeaker.tsx
+++ b/remotion/compositions/templates/layers/LayerOneSpeaker.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {GreenScreen} from '../../showcases/lyonJS/GreenScreen';
 import {LayerTitle} from './LayerTitle';
 import {BackgroundTriangle} from '../../../design/atoms/BackgroundTriangle';
+import {DefaultLayerProps} from './layers.types';
 
 export const LayerOneSpeaker: React.FC<DefaultLayerProps> = ({
 	title,

--- a/remotion/compositions/templates/layers/LayerTwoSpeaker.tsx
+++ b/remotion/compositions/templates/layers/LayerTwoSpeaker.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import {GreenScreen} from '../../showcases/lyonJS/GreenScreen';
 import {LayerTitle} from './LayerTitle';
 import {BackgroundTriangle} from '../../../design/atoms/BackgroundTriangle';
+import {DefaultLayerProps} from './layers.types';
 
 export const LayerTwoSpeaker: React.FC<DefaultLayerProps> = ({
 	title,

--- a/remotion/compositions/templates/layers/layers.types.ts
+++ b/remotion/compositions/templates/layers/layers.types.ts
@@ -4,7 +4,7 @@ type LayerBaseProps = {
 	decorationUrl?: string;
 };
 
-type DefaultLayerProps = LayerBaseProps & {
+export type DefaultLayerProps = LayerBaseProps & {
 	title?: string;
 	sponsorLogoUrl?: string;
 };

--- a/remotion/compositions/templates/layers/layers.types.ts
+++ b/remotion/compositions/templates/layers/layers.types.ts
@@ -1,4 +1,4 @@
-type LayerBaseProps = {
+export type LayerBaseProps = {
 	primaryColor?: string;
 	secondaryColor?: string;
 	decorationUrl?: string;

--- a/remotion/types/defaultProps.types.ts
+++ b/remotion/types/defaultProps.types.ts
@@ -3,7 +3,7 @@ export interface Speaker {
 	name: string;
 }
 
-export interface Talk {
+export interface DefaultProps {
 	title: string;
 	speakers: Speaker[];
 	date: string;

--- a/src/app/Code.tsx
+++ b/src/app/Code.tsx
@@ -1,14 +1,14 @@
 import {MouseEvent, useCallback} from 'react';
 import va from '@vercel/analytics';
-import {TouraineTechProps} from '../../remotion/compositions/showcases/snowcamp/Snowcamp';
 import {ReplayProps} from '../../app/templates/replay/page';
 import {TalkBrandedProps} from '../../remotion/compositions/templates/talk/branded/TalkBranded';
+import {DefaultProps} from '../../remotion/types/defaultProps.types';
 
 export const Code: React.FC<{
 	composition: string;
 	params:
 		| {[key: string]: string | undefined}
-		| TouraineTechProps
+		| DefaultProps
 		| ReplayProps
 		| TalkBrandedProps;
 }> = ({params, composition}) => {


### PR DESCRIPTION
## 🤔 Why do you want to make those changes?

There was a lot of types that where duplicated or miss-named.

## 🧑‍🔬 How did you make them?

I renamed the folder `Conferences.types.ts` to `DefaultProps.types.ts` and updated the types where they have been used. I also remove the duplicated types similar to the default props ones.

## 🧪 How to check them?

- Check the code
- See if there is duplications left
