### PR TITLE
feat(eslint): add imports organisation

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,25 @@
 		],
 		"@typescript-eslint/no-unused-vars": "error",
 		"@typescript-eslint/no-empty-function": "off",
-		"no-unused-vars": "off"
+		"no-unused-vars": "off",
+		"import/order": [
+			"error",
+			{
+				"groups": ["builtin", "external", "internal"],
+				"pathGroups": [
+					{
+						"pattern": "react",
+						"group": "external",
+						"position": "before"
+					}
+				],
+				"pathGroupsExcludedImportTypes": ["react"],
+				"newlines-between": "always",
+				"alphabetize": {
+					"order": "asc",
+					"caseInsensitive": true
+				}
+			}
+		]
 	}
 }

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,3 +2,4 @@
 . "$(dirname -- "$0")/_/husky.sh"
 
 pnpm pretty-quick --staged
+pnpm lint --fix

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import React from 'react';
+
 import {Player} from '@remotion/player';
-import {Meetup} from '../remotion/compositions/templates/meetup/Meetup';
-import {Talk} from '../remotion/compositions/templates/talk/Talk';
-import {Sponsor} from '../remotion/compositions/templates/sponsor/Sponsor';
+
 import {Event} from '../remotion/compositions/templates/event/Event';
+import {Meetup} from '../remotion/compositions/templates/meetup/Meetup';
+import {Sponsor} from '../remotion/compositions/templates/sponsor/Sponsor';
+import {Talk} from '../remotion/compositions/templates/talk/Talk';
 import RootLayout from '../src/app/RootLayout';
 import Image from 'next/image';
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,13 +3,13 @@
 import React from 'react';
 
 import {Player} from '@remotion/player';
+import Image from 'next/image';
 
 import {Event} from '../remotion/compositions/templates/event/Event';
 import {Meetup} from '../remotion/compositions/templates/meetup/Meetup';
 import {Sponsor} from '../remotion/compositions/templates/sponsor/Sponsor';
 import {Talk} from '../remotion/compositions/templates/talk/Talk';
 import RootLayout from '../src/app/RootLayout';
-import Image from 'next/image';
 
 interface Video {
 	id: string;

--- a/app/screens/layers/[mode]/page.tsx
+++ b/app/screens/layers/[mode]/page.tsx
@@ -2,6 +2,7 @@
 
 import {Player} from '@remotion/player';
 import {useSearchParams} from 'next/navigation';
+
 import LayerByMode from '../../../../src/app/LayerByMode';
 import {LayerMode} from '../../../../src/app/types/layerMode.types';
 

--- a/app/showcases/conferences/[conferenceName]/page.tsx
+++ b/app/showcases/conferences/[conferenceName]/page.tsx
@@ -1,23 +1,25 @@
 'use client';
 
-import {Snowcamp} from '../../../../remotion/compositions/showcases/snowcamp/Snowcamp';
-import {Devoxx2023} from '../../../../remotion/compositions/showcases/devoxx/Devoxx2023';
-import {MixitIntroTalk} from '../../../../remotion/compositions/showcases/mixit/MixitIntroTalk';
-import {TouraineTech2023} from '../../../../remotion/compositions/showcases/touraineTech/TouraineTech2023';
-import {VeryTechTrip} from '../../../../remotion/compositions/showcases/veryTechTrip/VeryTechTrip';
+import {useState} from 'react';
+
 import {Player} from '@remotion/player';
+import _ = require('lodash');
 import JSONInput from 'react-json-editor-ajrm';
 import locale from 'react-json-editor-ajrm/locale/en';
-import {useState} from 'react';
-import {defaultTalkValues} from '../../../../src/data/defaultValues';
+
 import {AlpesCraft} from '../../../../remotion/compositions/showcases/alpescraft/AlpesCraft';
-import {Code} from '../../../../src/app/Code';
 import {CampingDesSpeakers} from '../../../../remotion/compositions/showcases/campingDesSpeakers/CampingDesSpeakers';
-import _ = require('lodash');
-import {ReplayProps} from '../../../templates/replay/page';
-import {TalkBrandedProps} from '../../../../remotion/compositions/templates/talk/branded/TalkBranded';
+import {Devoxx2023} from '../../../../remotion/compositions/showcases/devoxx/Devoxx2023';
+import {MixitIntroTalk} from '../../../../remotion/compositions/showcases/mixit/MixitIntroTalk';
+import {Snowcamp} from '../../../../remotion/compositions/showcases/snowcamp/Snowcamp';
+import {TouraineTech2023} from '../../../../remotion/compositions/showcases/touraineTech/TouraineTech2023';
+import {VeryTechTrip} from '../../../../remotion/compositions/showcases/veryTechTrip/VeryTechTrip';
 import {Volcamp} from '../../../../remotion/compositions/showcases/volcamp/Volcamp';
+import {TalkBrandedProps} from '../../../../remotion/compositions/templates/talk/branded/TalkBranded';
 import {DefaultProps} from '../../../../remotion/types/defaultProps.types';
+import {Code} from '../../../../src/app/Code';
+import {defaultTalkValues} from '../../../../src/data/defaultValues';
+import {ReplayProps} from '../../../templates/replay/page';
 interface TalkTemplate {
 	component: React.FC<any>;
 	width: number;

--- a/app/showcases/layout.tsx
+++ b/app/showcases/layout.tsx
@@ -1,4 +1,5 @@
 import {ReactNode} from 'react';
+
 import '../../styles/globals.css';
 import RootLayout from '../../src/app/RootLayout';
 

--- a/app/templates/event/page.tsx
+++ b/app/templates/event/page.tsx
@@ -1,14 +1,15 @@
 'use client';
 
-import {useInputChange} from '../../../src/app/hooks/useInputChange';
 import {Player} from '@remotion/player';
-import {Form, Input} from '../../../src/app/forms/input';
-import {Code} from '../../../src/app/Code';
+
 import {Event} from '../../../remotion/compositions/templates/event/Event';
-import {encodeObjectValues} from '../../../src/app/utils/encodeObjectValues';
+import {Code} from '../../../src/app/Code';
 import {CopyUrlButton} from '../../../src/app/CopyUrlButton';
 import {FontPicker} from '../../../src/app/forms/FontPicker';
+import {Form, Input} from '../../../src/app/forms/input';
+import {useInputChange} from '../../../src/app/hooks/useInputChange';
 import {useSelectedFont} from '../../../src/app/hooks/useSelectedFont';
+import {encodeObjectValues} from '../../../src/app/utils/encodeObjectValues';
 
 export default function EventPage() {
 	const [title, setTitle] = useInputChange<string>('Apéro JS 🍾', 'title');

--- a/app/templates/layers/page.tsx
+++ b/app/templates/layers/page.tsx
@@ -1,13 +1,15 @@
 'use client';
 
 import {useCallback, useState} from 'react';
-import {LayerMode} from '../../../src/app/types/layerMode.types';
+
 import {Player} from '@remotion/player';
+
+import {ColorInput} from '../../../src/app/forms/colorInput';
 import {Form, Input} from '../../../src/app/forms/input';
+import {SelectInput} from '../../../src/app/forms/selectInput';
 import {useInputChange} from '../../../src/app/hooks/useInputChange';
 import LayerByMode from '../../../src/app/LayerByMode';
-import {SelectInput} from '../../../src/app/forms/selectInput';
-import {ColorInput} from '../../../src/app/forms/colorInput';
+import {LayerMode} from '../../../src/app/types/layerMode.types';
 
 export default function LayersPage() {
 	const [copied, setCopied] = useState(false);

--- a/app/templates/layout.tsx
+++ b/app/templates/layout.tsx
@@ -1,4 +1,5 @@
 import {ReactNode} from 'react';
+
 import '../../styles/globals.css';
 import RootLayout from '../../src/app/RootLayout';
 

--- a/app/templates/meetup/page.tsx
+++ b/app/templates/meetup/page.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import {useInputChange} from '../../../src/app/hooks/useInputChange';
 import {Player} from '@remotion/player';
+
 import {Meetup as MeetupComponent} from '../../../remotion/compositions/templates/meetup/Meetup';
 import {Code} from '../../../src/app/Code';
-import {Form, Input} from '../../../src/app/forms/input';
 import {CopyUrlButton} from '../../../src/app/CopyUrlButton';
+import {Form, Input} from '../../../src/app/forms/input';
+import {useInputChange} from '../../../src/app/hooks/useInputChange';
 import {encodeObjectValues} from '../../../src/app/utils/encodeObjectValues';
 
 export default function MeetupPage() {

--- a/app/templates/replay/page.tsx
+++ b/app/templates/replay/page.tsx
@@ -1,13 +1,14 @@
 'use client';
 
 import {ChangeEvent, useCallback, useState} from 'react';
-import {Player} from '@remotion/player';
-import {Code} from '../../../src/app/Code';
 
-import locale from 'react-json-editor-ajrm/locale/en';
+import {Player} from '@remotion/player';
 import JSONInput from 'react-json-editor-ajrm/index';
+import locale from 'react-json-editor-ajrm/locale/en';
+
 import {ReplayLyonJS} from '../../../remotion/compositions/showcases/lyonJS/Replay';
 import {Speaker} from '../../../remotion/types/defaultProps.types';
+import {Code} from '../../../src/app/Code';
 
 export interface ReplayProps {
 	title: string;

--- a/app/templates/silhouette/page.tsx
+++ b/app/templates/silhouette/page.tsx
@@ -1,14 +1,15 @@
 'use client';
 
 import {Player} from '@remotion/player';
-import {useInputChange} from '../../../src/app/hooks/useInputChange';
-import {Form, Input} from '../../../src/app/forms/input';
-import {Code} from '../../../src/app/Code';
+
 import {Silhouette} from '../../../remotion/compositions/templates/silhouette/Silhouette';
 import {Side} from '../../../remotion/compositions/templates/silhouette/Silhouette.type';
-import {SelectInput} from '../../../src/app/forms/selectInput';
-import {encodeObjectValues} from '../../../src/app/utils/encodeObjectValues';
+import {Code} from '../../../src/app/Code';
 import {CopyUrlButton} from '../../../src/app/CopyUrlButton';
+import {Form, Input} from '../../../src/app/forms/input';
+import {SelectInput} from '../../../src/app/forms/selectInput';
+import {useInputChange} from '../../../src/app/hooks/useInputChange';
+import {encodeObjectValues} from '../../../src/app/utils/encodeObjectValues';
 
 export default function SilhouettePage() {
 	const [title, setTitle] = useInputChange<string>(

--- a/app/templates/sponsor/page.tsx
+++ b/app/templates/sponsor/page.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import {Player} from '@remotion/player';
-import {useInputChange} from '../../../src/app/hooks/useInputChange';
-import {Form, Input} from '../../../src/app/forms/input';
-import {Code} from '../../../src/app/Code';
+
 import {Sponsor} from '../../../remotion/compositions/templates/sponsor/Sponsor';
-import {encodeObjectValues} from '../../../src/app/utils/encodeObjectValues';
+import {Code} from '../../../src/app/Code';
 import {CopyUrlButton} from '../../../src/app/CopyUrlButton';
+import {Form, Input} from '../../../src/app/forms/input';
+import {useInputChange} from '../../../src/app/hooks/useInputChange';
+import {encodeObjectValues} from '../../../src/app/utils/encodeObjectValues';
 
 export default function SponsorPage() {
 	const [companyName, setCompanyName] = useInputChange<string>(

--- a/app/templates/talks/talk/page.tsx
+++ b/app/templates/talks/talk/page.tsx
@@ -1,11 +1,12 @@
 'use client';
 
 import {Player} from '@remotion/player';
-import {useInputChange} from '../../../../src/app/hooks/useInputChange';
-import {Form, Input} from '../../../../src/app/forms/input';
-import {Code} from '../../../../src/app/Code';
+
 import {Talk} from '../../../../remotion/compositions/templates/talk/Talk';
+import {Code} from '../../../../src/app/Code';
 import {CopyUrlButton} from '../../../../src/app/CopyUrlButton';
+import {Form, Input} from '../../../../src/app/forms/input';
+import {useInputChange} from '../../../../src/app/hooks/useInputChange';
 import {encodeObjectValues} from '../../../../src/app/utils/encodeObjectValues';
 
 export default function TalkPage() {

--- a/app/templates/talks/talkBranded/page.tsx
+++ b/app/templates/talks/talkBranded/page.tsx
@@ -1,15 +1,16 @@
 'use client';
 
 import {Player} from '@remotion/player';
-import {useInputChange} from '../../../../src/app/hooks/useInputChange';
-import {Form, Input} from '../../../../src/app/forms/input';
+
+import {TalkBranded} from '../../../../remotion/compositions/templates/talk/branded/TalkBranded';
 import {Code} from '../../../../src/app/Code';
 import {CopyUrlButton} from '../../../../src/app/CopyUrlButton';
-import {encodeObjectValues} from '../../../../src/app/utils/encodeObjectValues';
-import {TalkBranded} from '../../../../remotion/compositions/templates/talk/branded/TalkBranded';
+import {Form, Input} from '../../../../src/app/forms/input';
+import {useInputChange} from '../../../../src/app/hooks/useInputChange';
 import {SelectInput} from '../../../../src/app/forms/selectInput';
-import {ColorInput} from '../../../../src/app/forms/colorInput';
+import {encodeObjectValues} from '../../../../src/app/utils/encodeObjectValues';
 import {InputDate} from '../../../../src/app/forms/inputDate';
+import {ColorInput} from '../../../../src/app/forms/colorInput';
 import {useInputDateChange} from '../../../../src/app/hooks/useInputDateChange';
 
 export default function BrandedTalkPage() {

--- a/app/templates/talks/talkBranded/page.tsx
+++ b/app/templates/talks/talkBranded/page.tsx
@@ -5,13 +5,13 @@ import {Player} from '@remotion/player';
 import {TalkBranded} from '../../../../remotion/compositions/templates/talk/branded/TalkBranded';
 import {Code} from '../../../../src/app/Code';
 import {CopyUrlButton} from '../../../../src/app/CopyUrlButton';
-import {Form, Input} from '../../../../src/app/forms/input';
-import {useInputChange} from '../../../../src/app/hooks/useInputChange';
-import {SelectInput} from '../../../../src/app/forms/selectInput';
-import {encodeObjectValues} from '../../../../src/app/utils/encodeObjectValues';
-import {InputDate} from '../../../../src/app/forms/inputDate';
 import {ColorInput} from '../../../../src/app/forms/colorInput';
+import {Form, Input} from '../../../../src/app/forms/input';
+import {InputDate} from '../../../../src/app/forms/inputDate';
+import {SelectInput} from '../../../../src/app/forms/selectInput';
+import {useInputChange} from '../../../../src/app/hooks/useInputChange';
 import {useInputDateChange} from '../../../../src/app/hooks/useInputDateChange';
+import {encodeObjectValues} from '../../../../src/app/utils/encodeObjectValues';
 
 export default function BrandedTalkPage() {
 	const [backgroundColor, setBackgroundColor] = useInputChange<string>(

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 	"scripts": {
 		"start": "remotion preview remotion/index.tsx",
 		"upgrade": "remotion upgrade",
-		"lint": "eslint remotion --ext ts,tsx,js,jsx",
+		"lint": "eslint remotion app src --ext ts,tsx,js,jsx",
 		"test": "jest",
 		"build": "next build",
 		"dev": "next dev",

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
 		"debug": "4.3.4",
 		"eslint": "8.44.0",
 		"eslint-config-next": "^13.4.2",
+		"eslint-plugin-import": "2.27.5",
 		"husky": "8.0.3",
 		"jest-environment-jsdom": "29.6.1",
 		"lodash": "4.17.21",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,9 @@ devDependencies:
   eslint-config-next:
     specifier: ^13.4.2
     version: 13.4.2(eslint@8.44.0)(typescript@5.1.6)
+  eslint-plugin-import:
+    specifier: 2.27.5
+    version: 2.27.5(@typescript-eslint/parser@5.61.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.44.0)
   husky:
     specifier: 8.0.3
     version: 8.0.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,7 +120,7 @@ devDependencies:
     version: 13.4.2(eslint@8.44.0)(typescript@5.1.6)
   eslint-plugin-import:
     specifier: 2.27.5
-    version: 2.27.5(@typescript-eslint/parser@5.61.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.44.0)
+    version: 2.27.5(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.5.5)(eslint@8.44.0)
   husky:
     specifier: 8.0.3
     version: 8.0.3

--- a/remotion/Video.tsx
+++ b/remotion/Video.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import {Folder} from 'remotion';
+
 import {ShowcasesComposition} from './compositions/showcases/Showcases.composition';
 import {TemplatesComposition} from './compositions/templates/Templates.composition';
 import {AtomsComposition} from './design/atoms/Atoms.composition';

--- a/remotion/compositions/showcases/Showcases.composition.tsx
+++ b/remotion/compositions/showcases/Showcases.composition.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
+
 import {Folder} from 'remotion';
 
-import {LyonJSComposition} from './lyonJS/LyonJS.composition';
 import {AlpesCraftComposition} from './alpescraft/AlpesCraft.composition';
-import {TouraineTechComposition} from './touraineTech/TouraineTech.composition';
-import {SnowcampComposition} from './snowcamp/Snowcamp.composition';
-import {VeryTechTripComposition} from './veryTechTrip/VeryTechTrip.composition';
-import {MixitComposition} from './mixit/Mixit.composition';
-import {DevoxxComposition} from './devoxx/Devoxx.composition';
 import {CampingDesSpeakersComposition} from './campingDesSpeakers/CampingDesSpeakers.composition';
 import {CodeInTheDarkComposition} from './codeInTheDark/CodeInTheDark.composition';
+import {DevoxxComposition} from './devoxx/Devoxx.composition';
+import {LyonJSComposition} from './lyonJS/LyonJS.composition';
+import {MixitComposition} from './mixit/Mixit.composition';
+import {SnowcampComposition} from './snowcamp/Snowcamp.composition';
+import {TouraineTechComposition} from './touraineTech/TouraineTech.composition';
+import {VeryTechTripComposition} from './veryTechTrip/VeryTechTrip.composition';
 import {VolcampComposition} from './volcamp/Volcamp.composition';
 
 export const ShowcasesComposition: React.FC = () => {

--- a/remotion/compositions/showcases/alpescraft/AlpesCraft.composition.tsx
+++ b/remotion/compositions/showcases/alpescraft/AlpesCraft.composition.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+
 import {Composition, Folder} from 'remotion';
+
 import {AlpesCraft} from './AlpesCraft';
 import {defaultTalkValues} from '../../../../src/data/defaultValues';
 

--- a/remotion/compositions/showcases/alpescraft/AlpesCraft.tsx
+++ b/remotion/compositions/showcases/alpescraft/AlpesCraft.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
+
 import {AbsoluteFill, Sequence} from 'remotion';
-import {TalkTitle} from './TalkTitle';
+
 import {Details} from './Details';
-import {Mountains} from './Mountains';
 import {Logo} from './Logo';
+import {Mountains} from './Mountains';
 import {Speakers} from './Speakers';
 import {TalkBackground} from './TalkBackground';
+import {TalkTitle} from './TalkTitle';
 import {Speaker} from '../../../types/defaultProps.types';
 
 export type AlpesCraftProps = {

--- a/remotion/compositions/showcases/alpescraft/Details.tsx
+++ b/remotion/compositions/showcases/alpescraft/Details.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import {useLottie} from '../../../hooks/useLottie';
+
 import {spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
 import {IconWithCaption} from '../../../design/molecules/IconWithCaption';
+import {useLottie} from '../../../hooks/useLottie';
 
 export const Details: React.FC<{
 	date: string;

--- a/remotion/compositions/showcases/alpescraft/Mountains.tsx
+++ b/remotion/compositions/showcases/alpescraft/Mountains.tsx
@@ -1,4 +1,5 @@
 import {Easing, interpolate, Sequence, useCurrentFrame} from 'remotion';
+
 import {SingleMountain} from './SingleMountain';
 
 export const Mountains = () => {

--- a/remotion/compositions/showcases/alpescraft/SingleMountain.tsx
+++ b/remotion/compositions/showcases/alpescraft/SingleMountain.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import {Img, staticFile} from 'remotion';
 
 export const SingleMountain: React.FC<{

--- a/remotion/compositions/showcases/alpescraft/Speakers.tsx
+++ b/remotion/compositions/showcases/alpescraft/Speakers.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import {Speaker} from '../../../types/defaultProps.types';
-import {SpeakersName} from './SpeakersName';
-import {AvatarWithCaption} from '../../../design/molecules/AvatarWithCaption';
+
 import {
 	Easing,
 	interpolate,
@@ -9,7 +7,11 @@ import {
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
+
+import {SpeakersName} from './SpeakersName';
 import {Text} from '../../../design/atoms/Text';
+import {AvatarWithCaption} from '../../../design/molecules/AvatarWithCaption';
+import {Speaker} from '../../../types/defaultProps.types';
 
 export const Speakers: React.FC<{speakers: Speaker[]}> = ({speakers}) => {
 	const frame = useCurrentFrame();

--- a/remotion/compositions/showcases/alpescraft/SpeakersName.tsx
+++ b/remotion/compositions/showcases/alpescraft/SpeakersName.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import {Easing, interpolate, useCurrentFrame} from 'remotion';
 
 export const SpeakersName: React.FC<{

--- a/remotion/compositions/showcases/alpescraft/TalkBackground.tsx
+++ b/remotion/compositions/showcases/alpescraft/TalkBackground.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+
 import {spring, staticFile, useCurrentFrame, useVideoConfig} from 'remotion';
+
 import {BackgroundFiller} from '../../../design/atoms/BackgroundFiller';
 
 export const TalkBackground = () => {

--- a/remotion/compositions/showcases/alpescraft/TalkTitle.tsx
+++ b/remotion/compositions/showcases/alpescraft/TalkTitle.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+
 import {Easing, interpolate, useCurrentFrame} from 'remotion';
+
 import {Title} from '../../../design/atoms/Title';
 
 export const TalkTitle: React.FC<{

--- a/remotion/compositions/showcases/campingDesSpeakers/CampingDesSpeakers.composition.tsx
+++ b/remotion/compositions/showcases/campingDesSpeakers/CampingDesSpeakers.composition.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+
 import {Composition, Folder} from 'remotion';
+
 import {CampingDesSpeakers} from './CampingDesSpeakers';
 import {Introduction} from './Introduction';
 

--- a/remotion/compositions/showcases/campingDesSpeakers/CampingDesSpeakers.tsx
+++ b/remotion/compositions/showcases/campingDesSpeakers/CampingDesSpeakers.tsx
@@ -1,6 +1,7 @@
 import {AbsoluteFill, Sequence} from 'remotion';
-import {Introduction} from './Introduction';
+
 import {TalkBackground} from './components/TalkBackground';
+import {Introduction} from './Introduction';
 import {Talk} from './Talk';
 
 export type Speaker = {

--- a/remotion/compositions/showcases/campingDesSpeakers/Introduction.tsx
+++ b/remotion/compositions/showcases/campingDesSpeakers/Introduction.tsx
@@ -1,4 +1,3 @@
-import {IntroBackground} from './components/IntroBackground';
 import {
 	Audio,
 	Easing,
@@ -7,11 +6,13 @@ import {
 	staticFile,
 	useCurrentFrame,
 } from 'remotion';
+
+import {BackTrees} from './components/BackTrees';
+import {FireCamp} from './components/FireCamp';
 import {FrontTrees} from './components/FrontTrees';
 import {Grass} from './components/Grass';
-import {BackTrees} from './components/BackTrees';
 import {Ground} from './components/Ground';
-import {FireCamp} from './components/FireCamp';
+import {IntroBackground} from './components/IntroBackground';
 import {Tent} from './components/Tent';
 
 export const Introduction = () => {

--- a/remotion/compositions/showcases/campingDesSpeakers/Talk.tsx
+++ b/remotion/compositions/showcases/campingDesSpeakers/Talk.tsx
@@ -5,6 +5,7 @@ import {
 	staticFile,
 	useCurrentFrame,
 } from 'remotion';
+
 import {TalkProps} from './CampingDesSpeakers';
 import {Details} from './components/Details';
 import {Speakers} from './components/Speakers';

--- a/remotion/compositions/showcases/campingDesSpeakers/components/BackTrees.tsx
+++ b/remotion/compositions/showcases/campingDesSpeakers/components/BackTrees.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import {
 	Img,
 	spring,
@@ -5,7 +7,6 @@ import {
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
-import React from 'react';
 
 export const BackTrees = () => {
 	const frame = useCurrentFrame();

--- a/remotion/compositions/showcases/campingDesSpeakers/components/Details.tsx
+++ b/remotion/compositions/showcases/campingDesSpeakers/components/Details.tsx
@@ -1,4 +1,5 @@
 import {interpolate, spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
 import {TalkDetails} from '../../../../design/molecules/TalkDetails';
 
 export const Details: React.FC<{

--- a/remotion/compositions/showcases/campingDesSpeakers/components/FireCamp.tsx
+++ b/remotion/compositions/showcases/campingDesSpeakers/components/FireCamp.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import {
 	Img,
 	interpolate,
@@ -6,7 +8,6 @@ import {
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
-import React from 'react';
 
 export const FireCamp = () => {
 	const frame = useCurrentFrame();

--- a/remotion/compositions/showcases/campingDesSpeakers/components/FrontTrees.tsx
+++ b/remotion/compositions/showcases/campingDesSpeakers/components/FrontTrees.tsx
@@ -1,5 +1,6 @@
-import {AbsoluteFill, spring, useCurrentFrame, useVideoConfig} from 'remotion';
 import React from 'react';
+
+import {AbsoluteFill, spring, useCurrentFrame, useVideoConfig} from 'remotion';
 
 export const FrontTrees: React.FC = () => {
 	const frame = useCurrentFrame();

--- a/remotion/compositions/showcases/campingDesSpeakers/components/Grass.tsx
+++ b/remotion/compositions/showcases/campingDesSpeakers/components/Grass.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import {
 	Img,
 	spring,
@@ -5,7 +7,6 @@ import {
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
-import React from 'react';
 
 export const Grass = () => {
 	const frame = useCurrentFrame();

--- a/remotion/compositions/showcases/campingDesSpeakers/components/Ground.tsx
+++ b/remotion/compositions/showcases/campingDesSpeakers/components/Ground.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import {
 	Img,
 	interpolate,
@@ -6,7 +8,6 @@ import {
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
-import React from 'react';
 
 export const Ground = () => {
 	const frame = useCurrentFrame();

--- a/remotion/compositions/showcases/campingDesSpeakers/components/IntroBackground.tsx
+++ b/remotion/compositions/showcases/campingDesSpeakers/components/IntroBackground.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import {AbsoluteFill, Img, Sequence, staticFile} from 'remotion';
 
 export const IntroBackground = () => {

--- a/remotion/compositions/showcases/campingDesSpeakers/components/Speakers.tsx
+++ b/remotion/compositions/showcases/campingDesSpeakers/components/Speakers.tsx
@@ -1,3 +1,4 @@
+import {loadFont} from '@remotion/google-fonts/YanoneKaffeesatz';
 import {
 	AbsoluteFill,
 	interpolate,
@@ -6,11 +7,11 @@ import {
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
-import {Speaker} from '../CampingDesSpeakers';
-import {AvatarWithCaption} from '../../../../design/molecules/AvatarWithCaption';
+
 import {Text} from '../../../../design/atoms/Text';
+import {AvatarWithCaption} from '../../../../design/molecules/AvatarWithCaption';
 import {IconWithCaption} from '../../../../design/molecules/IconWithCaption';
-import {loadFont} from '@remotion/google-fonts/YanoneKaffeesatz';
+import {Speaker} from '../CampingDesSpeakers';
 
 const {fontFamily} = loadFont();
 

--- a/remotion/compositions/showcases/campingDesSpeakers/components/TalkBackground.tsx
+++ b/remotion/compositions/showcases/campingDesSpeakers/components/TalkBackground.tsx
@@ -1,4 +1,5 @@
 import {interpolate, staticFile, useCurrentFrame} from 'remotion';
+
 import {BackgroundFiller} from '../../../../design/atoms/BackgroundFiller';
 
 export const TalkBackground = () => {

--- a/remotion/compositions/showcases/campingDesSpeakers/components/TalkTitle.tsx
+++ b/remotion/compositions/showcases/campingDesSpeakers/components/TalkTitle.tsx
@@ -1,6 +1,7 @@
-import {interpolate, spring, useCurrentFrame, useVideoConfig} from 'remotion';
-import {Title} from '../../../../design/atoms/Title';
 import {loadFont} from '@remotion/google-fonts/YanoneKaffeesatz';
+import {interpolate, spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
+import {Title} from '../../../../design/atoms/Title';
 
 const {fontFamily} = loadFont();
 

--- a/remotion/compositions/showcases/campingDesSpeakers/components/Tent.tsx
+++ b/remotion/compositions/showcases/campingDesSpeakers/components/Tent.tsx
@@ -1,5 +1,6 @@
-import {staticFile, Video} from 'remotion';
 import React from 'react';
+
+import {staticFile, Video} from 'remotion';
 
 export const Tent = () => {
 	return (

--- a/remotion/compositions/showcases/codeInTheDark/AnimatedCounter.tsx
+++ b/remotion/compositions/showcases/codeInTheDark/AnimatedCounter.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import {spring, useCurrentFrame, useVideoConfig} from 'remotion';
 
 export const AnimatedCounter: React.FC<{

--- a/remotion/compositions/showcases/codeInTheDark/Background.tsx
+++ b/remotion/compositions/showcases/codeInTheDark/Background.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import {AbsoluteFill, Img, staticFile} from 'remotion';
 
 export const Background = () => {

--- a/remotion/compositions/showcases/codeInTheDark/CodeInTheDark.composition.tsx
+++ b/remotion/compositions/showcases/codeInTheDark/CodeInTheDark.composition.tsx
@@ -1,4 +1,5 @@
 import {Composition, Folder} from 'remotion';
+
 import {CodeInTheDark} from './CodeInTheDark';
 
 export const CodeInTheDarkComposition: React.FC = () => {

--- a/remotion/compositions/showcases/codeInTheDark/CodeInTheDark.tsx
+++ b/remotion/compositions/showcases/codeInTheDark/CodeInTheDark.tsx
@@ -1,10 +1,11 @@
 import {AbsoluteFill, Audio, Sequence, staticFile} from 'remotion';
+
+import {Background} from './Background';
 import {Combo} from './Combo';
+import Details from './Details';
+import {Organisateurs} from './Organisateurs';
 import {Spotlight} from './Spotlight';
 import {Words} from './Words';
-import Details from './Details';
-import {Background} from './Background';
-import {Organisateurs} from './Organisateurs';
 import {loadLocalFont} from '../../../../src/app/utils/loadFont';
 
 loadLocalFont('PressStart2P', 'font/PressStart2P.ttf', 'truetype');

--- a/remotion/compositions/showcases/codeInTheDark/Combo.tsx
+++ b/remotion/compositions/showcases/codeInTheDark/Combo.tsx
@@ -1,6 +1,8 @@
-import _ from 'lodash';
 import React, {useEffect, useState} from 'react';
+
+import _ from 'lodash';
 import {interpolate, Loop, useCurrentFrame} from 'remotion';
+
 import {AnimatedCounter} from './AnimatedCounter';
 
 export const Combo: React.FC = () => {

--- a/remotion/compositions/showcases/codeInTheDark/Details.tsx
+++ b/remotion/compositions/showcases/codeInTheDark/Details.tsx
@@ -1,6 +1,7 @@
 import {useEffect, useState} from 'react';
-import {interpolate, useCurrentFrame} from 'remotion';
+
 import {loadFont} from '@remotion/google-fonts/AnonymousPro';
+import {interpolate, useCurrentFrame} from 'remotion';
 
 const {fontFamily} = loadFont();
 

--- a/remotion/compositions/showcases/codeInTheDark/Spotlight.tsx
+++ b/remotion/compositions/showcases/codeInTheDark/Spotlight.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import {interpolate, useCurrentFrame} from 'remotion';
 
 export const Spotlight = () => {

--- a/remotion/compositions/showcases/codeInTheDark/Words.tsx
+++ b/remotion/compositions/showcases/codeInTheDark/Words.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import {AbsoluteFill, interpolate, useCurrentFrame} from 'remotion';
 
 export const Words = () => {

--- a/remotion/compositions/showcases/devoxx/Balloons.tsx
+++ b/remotion/compositions/showcases/devoxx/Balloons.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
-import {Balloon5} from './balloons/Balloon5';
+
 import {Balloon1} from './balloons/Balloon1';
 import {Balloon2} from './balloons/Balloon2';
-import {Balloon4} from './balloons/Balloon4';
 import {Balloon3} from './balloons/Balloon3';
+import {Balloon4} from './balloons/Balloon4';
+import {Balloon5} from './balloons/Balloon5';
 
 export const Balloons: React.FC = () => {
 	return (

--- a/remotion/compositions/showcases/devoxx/Details.tsx
+++ b/remotion/compositions/showcases/devoxx/Details.tsx
@@ -1,5 +1,6 @@
-import {spring, useCurrentFrame, useVideoConfig} from 'remotion';
 import {loadFont} from '@remotion/google-fonts/Aldrich';
+import {spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
 import {IconWithCaption} from '../../../design/molecules/IconWithCaption';
 
 const {fontFamily} = loadFont();

--- a/remotion/compositions/showcases/devoxx/Devoxx.composition.tsx
+++ b/remotion/compositions/showcases/devoxx/Devoxx.composition.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+
 import {Composition, Folder} from 'remotion';
+
 import {Devoxx2023} from './Devoxx2023';
 import {defaultTalkValues} from '../../../../src/data/defaultValues';
 

--- a/remotion/compositions/showcases/devoxx/Devoxx2023.tsx
+++ b/remotion/compositions/showcases/devoxx/Devoxx2023.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import {
 	AbsoluteFill,
 	Img,
@@ -7,13 +9,13 @@ import {
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
-import {DefaultProps} from '../../../types/defaultProps.types';
+
+import Balloons from './Balloons';
+import {Details} from './Details';
 import {Logo} from './Logo';
 import {Speakers} from './Speakers';
 import {TalkTitle} from './TalkTitle';
-import React from 'react';
-import {Details} from './Details';
-import Balloons from './Balloons';
+import {DefaultProps} from '../../../types/defaultProps.types';
 
 export const Devoxx2023: React.FC<DefaultProps> = ({
 	title,

--- a/remotion/compositions/showcases/devoxx/Logo.tsx
+++ b/remotion/compositions/showcases/devoxx/Logo.tsx
@@ -1,3 +1,5 @@
+import React from 'react';
+
 import {
 	Img,
 	spring,
@@ -5,7 +7,6 @@ import {
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
-import React from 'react';
 
 export const Logo: React.FC = () => {
 	const frame = useCurrentFrame();

--- a/remotion/compositions/showcases/devoxx/SpeakerName.tsx
+++ b/remotion/compositions/showcases/devoxx/SpeakerName.tsx
@@ -1,3 +1,6 @@
+import React from 'react';
+
+import {loadFont} from '@remotion/google-fonts/Aldrich';
 import {
 	Img,
 	spring,
@@ -5,8 +8,7 @@ import {
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
-import React from 'react';
-import {loadFont} from '@remotion/google-fonts/Aldrich';
+
 import {Text} from '../../../design/atoms/Text';
 
 const {fontFamily} = loadFont();

--- a/remotion/compositions/showcases/devoxx/Speakers.tsx
+++ b/remotion/compositions/showcases/devoxx/Speakers.tsx
@@ -1,7 +1,8 @@
 import {AbsoluteFill, spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
 import {SpeakerName} from './SpeakerName';
-import {Speaker} from '../../../types/defaultProps.types';
 import {AvatarWithCaption} from '../../../design/molecules/AvatarWithCaption';
+import {Speaker} from '../../../types/defaultProps.types';
 
 export const Speakers: React.FC<{speakers: Speaker[]}> = ({speakers}) => {
 	const frame = useCurrentFrame();

--- a/remotion/compositions/showcases/devoxx/TalkTitle.tsx
+++ b/remotion/compositions/showcases/devoxx/TalkTitle.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+
+import {loadFont} from '@remotion/google-fonts/Aldrich';
 import {
 	Img,
 	interpolate,
@@ -7,7 +9,7 @@ import {
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
-import {loadFont} from '@remotion/google-fonts/Aldrich';
+
 import {Title} from '../../../design/atoms/Title';
 
 const {fontFamily} = loadFont();

--- a/remotion/compositions/showcases/lyonJS/BigSpeakers.tsx
+++ b/remotion/compositions/showcases/lyonJS/BigSpeakers.tsx
@@ -6,8 +6,9 @@ import {
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
-import {AvatarWithCaption} from '../../../design/molecules/AvatarWithCaption';
+
 import {Text} from '../../../design/atoms/Text';
+import {AvatarWithCaption} from '../../../design/molecules/AvatarWithCaption';
 import {Speaker} from '../../../types/defaultProps.types';
 
 export const BigSpeakers: React.FC<{speakers: Speaker[]; dropTop: number}> = ({

--- a/remotion/compositions/showcases/lyonJS/Details.tsx
+++ b/remotion/compositions/showcases/lyonJS/Details.tsx
@@ -1,3 +1,6 @@
+import React from 'react';
+
+import {loadFont} from '@remotion/google-fonts/Aldrich';
 import {
 	Img,
 	spring,
@@ -5,8 +8,7 @@ import {
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
-import {loadFont} from '@remotion/google-fonts/Aldrich';
-import React from 'react';
+
 import {IconWithCaption} from '../../../design/molecules/IconWithCaption';
 
 const {fontFamily} = loadFont();

--- a/remotion/compositions/showcases/lyonJS/LogoSponsor.tsx
+++ b/remotion/compositions/showcases/lyonJS/LogoSponsor.tsx
@@ -1,5 +1,5 @@
-import {Img, spring, useCurrentFrame, useVideoConfig} from 'remotion';
 import {loadFont} from '@remotion/google-fonts/Aldrich';
+import {Img, spring, useCurrentFrame, useVideoConfig} from 'remotion';
 
 const {fontFamily} = loadFont();
 

--- a/remotion/compositions/showcases/lyonJS/LyonJS.composition.tsx
+++ b/remotion/compositions/showcases/lyonJS/LyonJS.composition.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+
 import {Composition, Folder} from 'remotion';
+
 import {ReplayLyonJS} from './Replay';
 
 export const LyonJSComposition: React.FC = () => {

--- a/remotion/compositions/showcases/lyonJS/Replay.tsx
+++ b/remotion/compositions/showcases/lyonJS/Replay.tsx
@@ -1,11 +1,13 @@
-import {Audio, interpolate, Sequence, staticFile} from 'remotion';
-import {Logo} from './Logo';
-import {TalkTitle} from './TalkTitle';
-import {AbsoluteFill} from 'remotion';
-import {BigSpeakers} from './BigSpeakers';
 import React from 'react';
+
+import {Audio, interpolate, Sequence, staticFile} from 'remotion';
+import {AbsoluteFill} from 'remotion';
+
+import {BigSpeakers} from './BigSpeakers';
 import {Details} from './Details';
+import {Logo} from './Logo';
 import {LogoSponsor} from './LogoSponsor';
+import {TalkTitle} from './TalkTitle';
 import {BackgroundTriangle} from '../../../design/atoms/BackgroundTriangle';
 import {Speaker} from '../../../types/defaultProps.types';
 

--- a/remotion/compositions/showcases/lyonJS/TalkTitle.tsx
+++ b/remotion/compositions/showcases/lyonJS/TalkTitle.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import {interpolate, spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
 import {loadFont} from '@remotion/google-fonts/Aldrich';
+import {interpolate, spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
 import {Title} from '../../../design/atoms/Title';
 
 const {fontFamily} = loadFont();

--- a/remotion/compositions/showcases/lyonJS/Type.tsx
+++ b/remotion/compositions/showcases/lyonJS/Type.tsx
@@ -1,6 +1,7 @@
 import {Lottie} from '@remotion/lottie';
-import {useLottie} from '../../../hooks/useLottie';
 import {spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
+import {useLottie} from '../../../hooks/useLottie';
 
 export const Type: React.FC<{type: string}> = ({type}) => {
 	const frame = useCurrentFrame();

--- a/remotion/compositions/showcases/mixit/Details.tsx
+++ b/remotion/compositions/showcases/mixit/Details.tsx
@@ -1,4 +1,5 @@
 import {Sequence, spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
 import {TalkDetails} from '../../../design/molecules/TalkDetails';
 
 export const Details: React.FC<{

--- a/remotion/compositions/showcases/mixit/Mixit.composition.tsx
+++ b/remotion/compositions/showcases/mixit/Mixit.composition.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
+
 import {Composition, Folder} from 'remotion';
+
 import {Mixit2023} from './Mixit2023';
-import {defaultTalkValues} from '../../../../src/data/defaultValues';
 import {MixitIntro} from './MixitIntro';
 import {MixitIntroTalk} from './MixitIntroTalk';
 import {MixitSponsor} from './MixitSponsor';
+import {defaultTalkValues} from '../../../../src/data/defaultValues';
 
 export const MixitComposition: React.FC = () => {
 	return (

--- a/remotion/compositions/showcases/mixit/Mixit2023.tsx
+++ b/remotion/compositions/showcases/mixit/Mixit2023.tsx
@@ -1,10 +1,11 @@
 import {AbsoluteFill} from 'remotion';
-import {LyonSkyline} from './LyonSkyline';
-import {Logo} from './Logo';
-import {Speakers} from './Speakers';
+
 import {Details} from './Details';
-import {DefaultProps} from '../../../types/defaultProps.types';
+import {Logo} from './Logo';
+import {LyonSkyline} from './LyonSkyline';
+import {Speakers} from './Speakers';
 import {TalkTitle} from './TalkTitle';
+import {DefaultProps} from '../../../types/defaultProps.types';
 
 export const Mixit2023: React.FC<DefaultProps> = ({
 	title,

--- a/remotion/compositions/showcases/mixit/MixitIntro.tsx
+++ b/remotion/compositions/showcases/mixit/MixitIntro.tsx
@@ -1,3 +1,5 @@
+import {CSSProperties} from 'react';
+
 import {
 	AbsoluteFill,
 	Img,
@@ -5,7 +7,6 @@ import {
 	staticFile,
 	useCurrentFrame,
 } from 'remotion';
-import {CSSProperties} from 'react';
 
 const MixitLogo: React.FC = () => {
 	return (

--- a/remotion/compositions/showcases/mixit/MixitIntroTalk.tsx
+++ b/remotion/compositions/showcases/mixit/MixitIntroTalk.tsx
@@ -1,7 +1,8 @@
 import {AbsoluteFill} from 'remotion';
+
+import {Mixit2023} from './Mixit2023';
 import {MixitIntro} from './MixitIntro';
 import {DefaultProps} from '../../../types/defaultProps.types';
-import {Mixit2023} from './Mixit2023';
 
 export const MixitIntroTalk: React.FC<DefaultProps> = ({
 	title,

--- a/remotion/compositions/showcases/mixit/MixitSponsor.tsx
+++ b/remotion/compositions/showcases/mixit/MixitSponsor.tsx
@@ -1,8 +1,9 @@
 import {AbsoluteFill, Sequence} from 'remotion';
+
 import {BackgroundPicture} from './BackgroundPicture';
 import {BigLogo} from './BigLogo';
-import {Thanks} from './Thanks';
 import {LyonSkyline} from './LyonSkyline';
+import {Thanks} from './Thanks';
 
 export const MixitSponsor: React.FC<{
 	name: string;

--- a/remotion/compositions/showcases/mixit/Speakers.tsx
+++ b/remotion/compositions/showcases/mixit/Speakers.tsx
@@ -6,9 +6,10 @@ import {
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
-import {Speaker} from '../../../types/defaultProps.types';
-import {AvatarWithCaption} from '../../../design/molecules/AvatarWithCaption';
+
 import {Text} from '../../../design/atoms/Text';
+import {AvatarWithCaption} from '../../../design/molecules/AvatarWithCaption';
+import {Speaker} from '../../../types/defaultProps.types';
 
 export const Speakers: React.FC<{speakers: Speaker[]}> = ({speakers}) => {
 	const frame = useCurrentFrame();

--- a/remotion/compositions/showcases/mixit/TalkTitle.tsx
+++ b/remotion/compositions/showcases/mixit/TalkTitle.tsx
@@ -1,4 +1,5 @@
 import {interpolate, spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
 import {Title} from '../../../design/atoms/Title';
 
 export const TalkTitle: React.FC<{

--- a/remotion/compositions/showcases/snowcamp/Details.tsx
+++ b/remotion/compositions/showcases/snowcamp/Details.tsx
@@ -1,4 +1,5 @@
 import {spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
 import {TalkDetails} from '../../../design/molecules/TalkDetails';
 
 export const Details: React.FC<{

--- a/remotion/compositions/showcases/snowcamp/Snow.tsx
+++ b/remotion/compositions/showcases/snowcamp/Snow.tsx
@@ -1,6 +1,7 @@
 import {Lottie} from '@remotion/lottie';
-import {useLottie} from '../../../hooks/useLottie';
 import {interpolate, useCurrentFrame} from 'remotion';
+
+import {useLottie} from '../../../hooks/useLottie';
 
 export const Snow = () => {
 	const frame = useCurrentFrame();

--- a/remotion/compositions/showcases/snowcamp/Snowcamp.composition.tsx
+++ b/remotion/compositions/showcases/snowcamp/Snowcamp.composition.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+
 import {Composition, Folder} from 'remotion';
+
 import {Snowcamp} from './Snowcamp';
 import {defaultTalkValues} from '../../../../src/data/defaultValues';
 

--- a/remotion/compositions/showcases/snowcamp/Snowcamp.tsx
+++ b/remotion/compositions/showcases/snowcamp/Snowcamp.tsx
@@ -1,11 +1,13 @@
-import {AbsoluteFill, Sequence} from 'remotion';
-import {TalkTitle} from './TalkTitle';
-import {Details} from './Details';
-import {Speakers} from './Speakers';
 import React from 'react';
-import {Snow} from './Snow';
+
+import {AbsoluteFill, Sequence} from 'remotion';
+
+import {Details} from './Details';
 import {Logo} from './Logo';
+import {Snow} from './Snow';
+import {Speakers} from './Speakers';
 import {TalkBackground} from './TalkBackground';
+import {TalkTitle} from './TalkTitle';
 import {DefaultProps} from '../../../types/defaultProps.types';
 
 export const Snowcamp: React.FC<DefaultProps> = ({

--- a/remotion/compositions/showcases/snowcamp/Speakers.tsx
+++ b/remotion/compositions/showcases/snowcamp/Speakers.tsx
@@ -5,8 +5,9 @@ import {
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
-import {AvatarWithCaption} from '../../../design/molecules/AvatarWithCaption';
+
 import {Text} from '../../../design/atoms/Text';
+import {AvatarWithCaption} from '../../../design/molecules/AvatarWithCaption';
 import {Speaker} from '../../../types/defaultProps.types';
 
 export const Speakers: React.FC<{speakers: Speaker[]}> = ({speakers}) => {

--- a/remotion/compositions/showcases/snowcamp/TalkBackground.tsx
+++ b/remotion/compositions/showcases/snowcamp/TalkBackground.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+
 import {interpolate, staticFile, useCurrentFrame} from 'remotion';
+
 import {BackgroundFiller} from '../../../design/atoms/BackgroundFiller';
 
 export const TalkBackground = () => {

--- a/remotion/compositions/showcases/snowcamp/TalkTitle.tsx
+++ b/remotion/compositions/showcases/snowcamp/TalkTitle.tsx
@@ -1,4 +1,5 @@
 import {interpolate, spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
 import {Title} from '../../../design/atoms/Title';
 
 export const TalkTitle: React.FC<{

--- a/remotion/compositions/showcases/touraineTech/BigSpeakers.tsx
+++ b/remotion/compositions/showcases/touraineTech/BigSpeakers.tsx
@@ -6,8 +6,9 @@ import {
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
-import {AvatarWithCaption} from '../../../design/molecules/AvatarWithCaption';
+
 import {Text} from '../../../design/atoms/Text';
+import {AvatarWithCaption} from '../../../design/molecules/AvatarWithCaption';
 import {Speaker} from '../../../types/defaultProps.types';
 
 export const BigSpeakers: React.FC<{speakers: Speaker[]; dropTop: number}> = ({

--- a/remotion/compositions/showcases/touraineTech/Details.tsx
+++ b/remotion/compositions/showcases/touraineTech/Details.tsx
@@ -1,4 +1,5 @@
 import {Sequence, spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
 import {TalkDetails} from '../../../design/molecules/TalkDetails';
 
 export const Details: React.FC<{

--- a/remotion/compositions/showcases/touraineTech/Replay.tsx
+++ b/remotion/compositions/showcases/touraineTech/Replay.tsx
@@ -1,9 +1,10 @@
 import {Sequence} from 'remotion';
+import {AbsoluteFill} from 'remotion';
+
+import {BigSpeakers} from './BigSpeakers';
 import {Logo} from './Logo';
 import {TalkTitle} from './TalkTitle';
-import {AbsoluteFill} from 'remotion';
 import {Type} from './Type';
-import {BigSpeakers} from './BigSpeakers';
 import {BackgroundTriangle} from '../../../design/atoms/BackgroundTriangle';
 import {Speaker} from '../../../types/defaultProps.types';
 

--- a/remotion/compositions/showcases/touraineTech/Speakers.tsx
+++ b/remotion/compositions/showcases/touraineTech/Speakers.tsx
@@ -6,8 +6,9 @@ import {
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
-import {AvatarWithCaption} from '../../../design/molecules/AvatarWithCaption';
+
 import {Text} from '../../../design/atoms/Text';
+import {AvatarWithCaption} from '../../../design/molecules/AvatarWithCaption';
 import {Speaker} from '../../../types/defaultProps.types';
 
 export const Speakers: React.FC<{speakers: Speaker[]}> = ({speakers}) => {

--- a/remotion/compositions/showcases/touraineTech/SponsorTouraineTech2023.tsx
+++ b/remotion/compositions/showcases/touraineTech/SponsorTouraineTech2023.tsx
@@ -1,8 +1,9 @@
 import {AbsoluteFill} from 'remotion';
+
 import {Logo} from './Logo';
 import {TalkTitle} from './TalkTitle';
-import {SponsorLogo} from '../../templates/sponsor/SponsorLogo';
 import {BackgroundTriangle} from '../../../design/atoms/BackgroundTriangle';
+import {SponsorLogo} from '../../templates/sponsor/SponsorLogo';
 
 export type SponsorProps = {
 	message: string;

--- a/remotion/compositions/showcases/touraineTech/TalkTitle.tsx
+++ b/remotion/compositions/showcases/touraineTech/TalkTitle.tsx
@@ -1,4 +1,5 @@
 import {interpolate, spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
 import {Title} from '../../../design/atoms/Title';
 
 export const TalkTitle: React.FC<{

--- a/remotion/compositions/showcases/touraineTech/TouraineTech.composition.tsx
+++ b/remotion/compositions/showcases/touraineTech/TouraineTech.composition.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
+
 import {Composition, Folder} from 'remotion';
+
+import {Replay} from './Replay';
+import {SponsorTouraineTech2023} from './SponsorTouraineTech2023';
 import {TouraineTech2023} from './TouraineTech2023';
 import {defaultTalkValues} from '../../../../src/data/defaultValues';
-import {SponsorTouraineTech2023} from './SponsorTouraineTech2023';
-import {Replay} from './Replay';
 
 export const TouraineTechComposition: React.FC = () => {
 	return (

--- a/remotion/compositions/showcases/touraineTech/TouraineTech2023.tsx
+++ b/remotion/compositions/showcases/touraineTech/TouraineTech2023.tsx
@@ -1,9 +1,9 @@
 import {AbsoluteFill} from 'remotion';
-import {Logo} from './Logo';
 
-import {TalkTitle} from './TalkTitle';
 import {Details} from './Details';
+import {Logo} from './Logo';
 import {Speakers} from './Speakers';
+import {TalkTitle} from './TalkTitle';
 import {BackgroundTriangle} from '../../../design/atoms/BackgroundTriangle';
 import {DefaultProps} from '../../../types/defaultProps.types';
 

--- a/remotion/compositions/showcases/touraineTech/Type.tsx
+++ b/remotion/compositions/showcases/touraineTech/Type.tsx
@@ -1,6 +1,8 @@
-import {spring, useCurrentFrame, useVideoConfig} from 'remotion';
-import {TalkDetails} from '../../../design/molecules/TalkDetails';
 import React from 'react';
+
+import {spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
+import {TalkDetails} from '../../../design/molecules/TalkDetails';
 
 export const Type: React.FC<{type: string}> = ({type}) => {
 	const frame = useCurrentFrame();

--- a/remotion/compositions/showcases/veryTechTrip/Background.tsx
+++ b/remotion/compositions/showcases/veryTechTrip/Background.tsx
@@ -1,10 +1,11 @@
+import {CSSProperties} from 'react';
+
 import {
 	AbsoluteFill,
 	interpolate,
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
-import {CSSProperties} from 'react';
 
 const Rect: React.FC<{style?: CSSProperties}> = ({style}) => {
 	return (

--- a/remotion/compositions/showcases/veryTechTrip/Details.tsx
+++ b/remotion/compositions/showcases/veryTechTrip/Details.tsx
@@ -1,7 +1,9 @@
+import React, {CSSProperties} from 'react';
+
 import {spring} from 'remotion';
 import {useVideoConfig} from 'remotion';
 import {useCurrentFrame} from 'remotion';
-import React, {CSSProperties} from 'react';
+
 import {TalkDetails} from '../../../design/molecules/TalkDetails';
 
 export const Details: React.FC<{style?: CSSProperties; time: string}> = ({

--- a/remotion/compositions/showcases/veryTechTrip/FadeIn.tsx
+++ b/remotion/compositions/showcases/veryTechTrip/FadeIn.tsx
@@ -1,4 +1,5 @@
 import {ReactNode} from 'react';
+
 import {interpolate, useCurrentFrame} from 'remotion';
 
 export const FadeIn: React.FC<{children: ReactNode}> = ({children}) => {

--- a/remotion/compositions/showcases/veryTechTrip/Speakers.tsx
+++ b/remotion/compositions/showcases/veryTechTrip/Speakers.tsx
@@ -1,9 +1,11 @@
-import {Sequence} from 'remotion';
-import {Speaker as SpeakerType} from '../../../types/defaultProps.types';
 import React from 'react';
+
+import {Sequence} from 'remotion';
+
 import {FadeIn} from './FadeIn';
-import {AvatarWithCaption} from '../../../design/molecules/AvatarWithCaption';
 import {Text} from '../../../design/atoms/Text';
+import {AvatarWithCaption} from '../../../design/molecules/AvatarWithCaption';
+import {Speaker as SpeakerType} from '../../../types/defaultProps.types';
 
 const Speaker: React.FC<{speaker: SpeakerType; index: number}> = ({
 	speaker: {name, picture},

--- a/remotion/compositions/showcases/veryTechTrip/TalkTitle.tsx
+++ b/remotion/compositions/showcases/veryTechTrip/TalkTitle.tsx
@@ -1,4 +1,5 @@
 import {interpolate, spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
 import {Title} from '../../../design/atoms/Title';
 
 export const TalkTitle: React.FC<{

--- a/remotion/compositions/showcases/veryTechTrip/VeryTechTrip.composition.tsx
+++ b/remotion/compositions/showcases/veryTechTrip/VeryTechTrip.composition.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+
 import {Composition, Folder} from 'remotion';
+
 import {VeryTechTrip} from './VeryTechTrip';
 import {defaultTalkValues} from '../../../../src/data/defaultValues';
 

--- a/remotion/compositions/showcases/veryTechTrip/VeryTechTrip.tsx
+++ b/remotion/compositions/showcases/veryTechTrip/VeryTechTrip.tsx
@@ -1,13 +1,15 @@
+import React from 'react';
+
 import {useVideoConfig} from 'remotion';
 import {useCurrentFrame} from 'remotion';
 import {spring} from 'remotion';
 import {AbsoluteFill, Img, Sequence, Audio, staticFile} from 'remotion';
-import React from 'react';
+
 import {Background} from './Background';
-import {Speakers} from './Speakers';
-import {TalkTitle} from './TalkTitle';
 import {Details} from './Details';
 import {Logo} from './Logo';
+import {Speakers} from './Speakers';
+import {TalkTitle} from './TalkTitle';
 import {DefaultProps} from '../../../types/defaultProps.types';
 
 export const VeryTechTrip: React.FC<DefaultProps> = ({

--- a/remotion/compositions/showcases/volcamp/Volcamp.composition.tsx
+++ b/remotion/compositions/showcases/volcamp/Volcamp.composition.tsx
@@ -1,4 +1,5 @@
 import {Composition, Folder} from 'remotion';
+
 import {Volcamp} from './Volcamp';
 
 export const VolcampComposition = () => {

--- a/remotion/compositions/showcases/volcamp/Volcamp.tsx
+++ b/remotion/compositions/showcases/volcamp/Volcamp.tsx
@@ -1,8 +1,9 @@
+import {loadFont} from '@remotion/google-fonts/Poppins';
 import {AbsoluteFill, Img, Sequence, staticFile} from 'remotion';
-import {Transition} from './components/Transition';
+
 import {Eruption} from './components/Eruption';
 import {Talk, TalkProps} from './components/Talk';
-import {loadFont} from '@remotion/google-fonts/Poppins';
+import {Transition} from './components/Transition';
 
 const {fontFamily} = loadFont();
 

--- a/remotion/compositions/showcases/volcamp/components/Details.tsx
+++ b/remotion/compositions/showcases/volcamp/components/Details.tsx
@@ -1,4 +1,3 @@
-import {TalkDetails} from '../../../../design/molecules/TalkDetails';
 import {
 	AbsoluteFill,
 	Img,
@@ -8,6 +7,8 @@ import {
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
+
+import {TalkDetails} from '../../../../design/molecules/TalkDetails';
 
 export const Details: React.FC<{
 	date?: string;

--- a/remotion/compositions/showcases/volcamp/components/Eruption.tsx
+++ b/remotion/compositions/showcases/volcamp/components/Eruption.tsx
@@ -1,5 +1,6 @@
-import {Volcano} from './Volcano';
 import {useCurrentFrame} from 'remotion';
+
+import {Volcano} from './Volcano';
 
 export const Eruption = () => {
 	const frame = useCurrentFrame();

--- a/remotion/compositions/showcases/volcamp/components/Speakers.tsx
+++ b/remotion/compositions/showcases/volcamp/components/Speakers.tsx
@@ -1,5 +1,6 @@
-import {Text} from '../../../../design/atoms/Text';
 import {Img, spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
+import {Text} from '../../../../design/atoms/Text';
 
 export type speakerProps = {
 	speakers: {name: string; picture: string; company?: string; role?: string}[];

--- a/remotion/compositions/showcases/volcamp/components/Talk.tsx
+++ b/remotion/compositions/showcases/volcamp/components/Talk.tsx
@@ -1,8 +1,8 @@
-import {TalkTitle} from './TalkTitle';
 import {Details} from './Details';
-import {Theme, ThemeProps} from './Theme';
-import {speakerProps, Speakers} from './Speakers';
 import {Logo} from './Logo';
+import {speakerProps, Speakers} from './Speakers';
+import {TalkTitle} from './TalkTitle';
+import {Theme, ThemeProps} from './Theme';
 
 export type TalkProps = {
 	themeName: ThemeProps['themeName'];

--- a/remotion/compositions/showcases/volcamp/components/TalkTitle.tsx
+++ b/remotion/compositions/showcases/volcamp/components/TalkTitle.tsx
@@ -1,5 +1,6 @@
-import {Title} from '../../../../design/atoms/Title';
 import {interpolate, useCurrentFrame} from 'remotion';
+
+import {Title} from '../../../../design/atoms/Title';
 
 export const TalkTitle: React.FC<{
 	title: string;

--- a/remotion/compositions/templates/Templates.composition.tsx
+++ b/remotion/compositions/templates/Templates.composition.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
+
 import {Folder} from 'remotion';
 
+import {EventsComposition} from './event/Events.composition';
+import {LayersComposition} from './layers/Layers.composition';
+import {MeetupComposition} from './meetup/Meetup.composition';
+import {SilhouetteComposition} from './silhouette/Silhouette.composition';
 import {SponsorsComposition} from './sponsor/Sponsors.composition';
 import {TalksComposition} from './talk/Talks.composition';
-import {MeetupComposition} from './meetup/Meetup.composition';
-import {EventsComposition} from './event/Events.composition';
-import {SilhouetteComposition} from './silhouette/Silhouette.composition';
-import {LayersComposition} from './layers/Layers.composition';
 
 export const TemplatesComposition: React.FC = () => {
 	return (

--- a/remotion/compositions/templates/event/Event.tsx
+++ b/remotion/compositions/templates/event/Event.tsx
@@ -1,8 +1,9 @@
 import {AbsoluteFill, Sequence} from 'remotion';
-import {LottieAsset} from '../../../design/atoms/LottieAsset';
-import {EventTitle} from './EventTitle';
-import {Paillettes} from '../../../design/atoms/Paillettes';
+
 import {EventBackground} from './EventBackground';
+import {EventTitle} from './EventTitle';
+import {LottieAsset} from '../../../design/atoms/LottieAsset';
+import {Paillettes} from '../../../design/atoms/Paillettes';
 
 export const Event: React.FC<{
 	backgroundImg?: string;

--- a/remotion/compositions/templates/event/EventBackground.tsx
+++ b/remotion/compositions/templates/event/EventBackground.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import {BackgroundFiller} from '../../../design/atoms/BackgroundFiller';
+
 import {spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
+import {BackgroundFiller} from '../../../design/atoms/BackgroundFiller';
 
 export const EventBackground: React.FC<{backgroundImg: string}> = ({
 	backgroundImg,

--- a/remotion/compositions/templates/event/EventTitle.tsx
+++ b/remotion/compositions/templates/event/EventTitle.tsx
@@ -1,4 +1,5 @@
 import {spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
 import {Title} from '../../../design/atoms/Title';
 
 export const EventTitle: React.FC<{

--- a/remotion/compositions/templates/event/Events.composition.tsx
+++ b/remotion/compositions/templates/event/Events.composition.tsx
@@ -1,4 +1,5 @@
 import {Composition, Folder} from 'remotion';
+
 import {Event} from './Event';
 
 export const EventsComposition: React.FC = () => {

--- a/remotion/compositions/templates/layers/LayerFullScreen.tsx
+++ b/remotion/compositions/templates/layers/LayerFullScreen.tsx
@@ -1,8 +1,10 @@
-import {AbsoluteFill, Img} from 'remotion';
 import React from 'react';
-import {GreenScreen} from '../../showcases/lyonJS/GreenScreen';
-import {BackgroundTriangle} from '../../../design/atoms/BackgroundTriangle';
+
+import {AbsoluteFill, Img} from 'remotion';
+
 import {LayerBaseProps} from './layers.types';
+import {BackgroundTriangle} from '../../../design/atoms/BackgroundTriangle';
+import {GreenScreen} from '../../showcases/lyonJS/GreenScreen';
 
 export const LayerFullScreen: React.FC<LayerBaseProps> = ({
 	primaryColor,

--- a/remotion/compositions/templates/layers/LayerOneSpeaker.tsx
+++ b/remotion/compositions/templates/layers/LayerOneSpeaker.tsx
@@ -1,9 +1,11 @@
-import {AbsoluteFill, Img} from 'remotion';
 import React from 'react';
-import {GreenScreen} from '../../showcases/lyonJS/GreenScreen';
+
+import {AbsoluteFill, Img} from 'remotion';
+
+import {DefaultLayerProps} from './layers.types';
 import {LayerTitle} from './LayerTitle';
 import {BackgroundTriangle} from '../../../design/atoms/BackgroundTriangle';
-import {DefaultLayerProps} from './layers.types';
+import {GreenScreen} from '../../showcases/lyonJS/GreenScreen';
 
 export const LayerOneSpeaker: React.FC<DefaultLayerProps> = ({
 	title,

--- a/remotion/compositions/templates/layers/LayerTitle.tsx
+++ b/remotion/compositions/templates/layers/LayerTitle.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+
 import {loadFont} from '@remotion/google-fonts/Aldrich';
+
 import {Title} from '../../../design/atoms/Title';
 
 const {fontFamily} = loadFont();

--- a/remotion/compositions/templates/layers/LayerTwoSpeaker.tsx
+++ b/remotion/compositions/templates/layers/LayerTwoSpeaker.tsx
@@ -1,9 +1,11 @@
-import {AbsoluteFill, Img} from 'remotion';
 import React from 'react';
-import {GreenScreen} from '../../showcases/lyonJS/GreenScreen';
+
+import {AbsoluteFill, Img} from 'remotion';
+
+import {DefaultLayerProps} from './layers.types';
 import {LayerTitle} from './LayerTitle';
 import {BackgroundTriangle} from '../../../design/atoms/BackgroundTriangle';
-import {DefaultLayerProps} from './layers.types';
+import {GreenScreen} from '../../showcases/lyonJS/GreenScreen';
 
 export const LayerTwoSpeaker: React.FC<DefaultLayerProps> = ({
 	title,

--- a/remotion/compositions/templates/layers/Layers.composition.tsx
+++ b/remotion/compositions/templates/layers/Layers.composition.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+
 import {Folder, Still} from 'remotion';
+
 import {LayerFullScreen} from './LayerFullScreen';
 import {LayerOneSpeaker} from './LayerOneSpeaker';
 import {LayerTwoSpeaker} from './LayerTwoSpeaker';

--- a/remotion/compositions/templates/meetup/Meetup.composition.tsx
+++ b/remotion/compositions/templates/meetup/Meetup.composition.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+
 import {Composition, Folder} from 'remotion';
+
 import {Meetup} from './Meetup';
 import {Register} from './Register';
 

--- a/remotion/compositions/templates/meetup/Meetup.tsx
+++ b/remotion/compositions/templates/meetup/Meetup.tsx
@@ -1,9 +1,11 @@
+import React from 'react';
+
 import {AbsoluteFill, Sequence, staticFile} from 'remotion';
+
+import {MeetupBackground} from './MeetupBackground';
+import {MeetupDate} from './MeetupDate';
 import {MeetupPresentation} from './MeetupPresentation';
 import {Register} from './Register';
-import {MeetupDate} from './MeetupDate';
-import React from 'react';
-import {MeetupBackground} from './MeetupBackground';
 
 export type MeetupProps = {
 	eventLogo?: string;

--- a/remotion/compositions/templates/meetup/MeetupBackground.tsx
+++ b/remotion/compositions/templates/meetup/MeetupBackground.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+
 import {spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
 import {BackgroundFiller} from '../../../design/atoms/BackgroundFiller';
 
 export const MeetupBackground: React.FC<{backgroundImg: string}> = ({

--- a/remotion/compositions/templates/meetup/MeetupDate.tsx
+++ b/remotion/compositions/templates/meetup/MeetupDate.tsx
@@ -1,6 +1,7 @@
-import {AbsoluteFill, spring, useCurrentFrame, useVideoConfig} from 'remotion';
-import {Title} from '../../../design/atoms/Title';
 import {Lottie} from '@remotion/lottie';
+import {AbsoluteFill, spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
+import {Title} from '../../../design/atoms/Title';
 import {useLottie} from '../../../hooks/useLottie';
 
 export const MeetupDate: React.FC<{date: string}> = ({date}) => {

--- a/remotion/compositions/templates/meetup/MeetupLogo.tsx
+++ b/remotion/compositions/templates/meetup/MeetupLogo.tsx
@@ -1,4 +1,5 @@
 import {AbsoluteFill, spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
 import {EventLogo} from '../../../design/atoms/EventLogo';
 
 export type MeetupLogoProps = {

--- a/remotion/compositions/templates/meetup/MeetupPresentation.tsx
+++ b/remotion/compositions/templates/meetup/MeetupPresentation.tsx
@@ -1,6 +1,7 @@
 import {AbsoluteFill} from 'remotion';
-import {MeetupTitle} from './MeetupTitle';
+
 import {MeetupLogo} from './MeetupLogo';
+import {MeetupTitle} from './MeetupTitle';
 
 export type MeetupPresentationProps = {
 	eventLogo?: string;

--- a/remotion/compositions/templates/meetup/MeetupTitle.tsx
+++ b/remotion/compositions/templates/meetup/MeetupTitle.tsx
@@ -1,4 +1,5 @@
 import {spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
 import {Title} from '../../../design/atoms/Title';
 
 export const MeetupTitle: React.FC<{

--- a/remotion/compositions/templates/silhouette/Silhouette.composition.tsx
+++ b/remotion/compositions/templates/silhouette/Silhouette.composition.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+
 import {Composition, Folder} from 'remotion';
+
 import {Silhouette} from './Silhouette';
 
 export const SilhouetteComposition: React.FC = () => {

--- a/remotion/compositions/templates/silhouette/Silhouette.tsx
+++ b/remotion/compositions/templates/silhouette/Silhouette.tsx
@@ -1,9 +1,11 @@
-import {AbsoluteFill, Sequence} from 'remotion';
 import React from 'react';
+
+import {AbsoluteFill, Sequence} from 'remotion';
+
 import {Side} from './Silhouette.type';
+import {SilhouetteLogo} from './SilhouetteLogo';
 import {SilhouettePicture} from './SilhouettePicture';
 import {SilhouetteTitle} from './SilhouetteTitle';
-import {SilhouetteLogo} from './SilhouetteLogo';
 import {BackgroundFiller} from '../../../design/atoms/BackgroundFiller';
 
 export const Silhouette: React.FC<{

--- a/remotion/compositions/templates/silhouette/SilhouetteLogo.tsx
+++ b/remotion/compositions/templates/silhouette/SilhouetteLogo.tsx
@@ -1,5 +1,7 @@
-import {Easing, Img, interpolate, useCurrentFrame} from 'remotion';
 import React from 'react';
+
+import {Easing, Img, interpolate, useCurrentFrame} from 'remotion';
+
 import {Side} from './Silhouette.type';
 
 export const SilhouetteLogo: React.FC<{logoUrl: string; side: Side}> = ({

--- a/remotion/compositions/templates/silhouette/SilhouettePicture.tsx
+++ b/remotion/compositions/templates/silhouette/SilhouettePicture.tsx
@@ -1,5 +1,7 @@
-import {Easing, Img, interpolate, useCurrentFrame} from 'remotion';
 import React from 'react';
+
+import {Easing, Img, interpolate, useCurrentFrame} from 'remotion';
+
 import {Side} from './Silhouette.type';
 
 const DURATION = 20;

--- a/remotion/compositions/templates/silhouette/SilhouetteTitle.tsx
+++ b/remotion/compositions/templates/silhouette/SilhouetteTitle.tsx
@@ -1,5 +1,5 @@
-import {Title} from '../../../design/atoms/Title';
 import React from 'react';
+
 import {
 	Easing,
 	interpolate,
@@ -7,6 +7,8 @@ import {
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
+
+import {Title} from '../../../design/atoms/Title';
 
 export const SilhouetteTitle: React.FC<{title: string}> = ({title}) => {
 	const frame = useCurrentFrame();

--- a/remotion/compositions/templates/sponsor/Sponsor.tsx
+++ b/remotion/compositions/templates/sponsor/Sponsor.tsx
@@ -1,9 +1,10 @@
 import {AbsoluteFill, Sequence, staticFile} from 'remotion';
+
+import {SponsorBackground} from './SponsorBackground';
+import {SponsorMap} from './SponsorMap';
 import {SponsorOrgaLogo} from './SponsorOrgaLogo';
 import {SponsorPresentation} from './SponsorPresentation';
 import {SponsorThanks} from './SponsorThanks';
-import {SponsorMap} from './SponsorMap';
-import {SponsorBackground} from './SponsorBackground';
 
 export const Sponsor: React.FC<{
 	companyName?: string;

--- a/remotion/compositions/templates/sponsor/SponsorBackground.tsx
+++ b/remotion/compositions/templates/sponsor/SponsorBackground.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import {BackgroundFiller} from '../../../design/atoms/BackgroundFiller';
+
 import {spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
+import {BackgroundFiller} from '../../../design/atoms/BackgroundFiller';
 
 export const SponsorBackground: React.FC<{backgroundImg: string}> = ({
 	backgroundImg,

--- a/remotion/compositions/templates/sponsor/SponsorMap.tsx
+++ b/remotion/compositions/templates/sponsor/SponsorMap.tsx
@@ -1,7 +1,8 @@
-import {AbsoluteFill, spring, useCurrentFrame, useVideoConfig} from 'remotion';
-import {useLottie} from '../../../hooks/useLottie';
 import {Lottie} from '@remotion/lottie';
+import {AbsoluteFill, spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
 import {Title} from '../../../design/atoms/Title';
+import {useLottie} from '../../../hooks/useLottie';
 
 export const SponsorMap: React.FC<{
 	localisation?: string;

--- a/remotion/compositions/templates/sponsor/SponsorName.tsx
+++ b/remotion/compositions/templates/sponsor/SponsorName.tsx
@@ -1,4 +1,5 @@
 import {interpolate, spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
 import {Text} from '../../../design/atoms/Text';
 
 export const SponsorName: React.FC<{

--- a/remotion/compositions/templates/sponsor/SponsorOrgaLogo.tsx
+++ b/remotion/compositions/templates/sponsor/SponsorOrgaLogo.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import {EventLogo} from '../../../design/atoms/EventLogo';
+
 import {interpolate, spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
+import {EventLogo} from '../../../design/atoms/EventLogo';
 
 export const SponsorOrgaLogo: React.FC = () => {
 	const frame = useCurrentFrame();

--- a/remotion/compositions/templates/sponsor/SponsorPresentation.tsx
+++ b/remotion/compositions/templates/sponsor/SponsorPresentation.tsx
@@ -1,6 +1,7 @@
-import {SponsorName} from './SponsorName';
-import {SponsorLogo} from './SponsorLogo';
 import {AbsoluteFill} from 'remotion';
+
+import {SponsorLogo} from './SponsorLogo';
+import {SponsorName} from './SponsorName';
 
 export const SponsorPresentation: React.FC<{
 	companyName?: string;

--- a/remotion/compositions/templates/sponsor/SponsorThanks.tsx
+++ b/remotion/compositions/templates/sponsor/SponsorThanks.tsx
@@ -1,6 +1,7 @@
 import {Lottie} from '@remotion/lottie';
-import {useLottie} from '../../../hooks/useLottie';
 import {AbsoluteFill} from 'remotion';
+
+import {useLottie} from '../../../hooks/useLottie';
 
 export const SponsorThanks: React.FC = () => {
 	const illustration = useLottie('lf20_sqpjokxl');

--- a/remotion/compositions/templates/sponsor/Sponsors.composition.tsx
+++ b/remotion/compositions/templates/sponsor/Sponsors.composition.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+
 import {Composition, Folder} from 'remotion';
+
 import {Sponsor} from './Sponsor';
 
 export const SponsorsComposition: React.FC = () => {

--- a/remotion/compositions/templates/talk/SpeakerAndTitle.tsx
+++ b/remotion/compositions/templates/talk/SpeakerAndTitle.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import {
 	interpolate,
 	Sequence,
@@ -6,6 +7,7 @@ import {
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
+
 import {TalkSpeaker} from './TalkSpeaker';
 import {Title} from '../../../design/atoms/Title';
 

--- a/remotion/compositions/templates/talk/Talk.tsx
+++ b/remotion/compositions/templates/talk/Talk.tsx
@@ -1,8 +1,10 @@
-import {AbsoluteFill, Sequence, staticFile} from 'remotion';
-import {EventLogo} from '../../../design/atoms/EventLogo';
 import React from 'react';
+
+import {AbsoluteFill, Sequence, staticFile} from 'remotion';
+
 import {SpeakerAndTitle} from './SpeakerAndTitle';
 import {TalkBackground} from './TalkBackground';
+import {EventLogo} from '../../../design/atoms/EventLogo';
 
 export const Talk: React.FC<{
 	eventLogo?: string;

--- a/remotion/compositions/templates/talk/TalkBackground.tsx
+++ b/remotion/compositions/templates/talk/TalkBackground.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import {BackgroundFiller} from '../../../design/atoms/BackgroundFiller';
+
 import {spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
+import {BackgroundFiller} from '../../../design/atoms/BackgroundFiller';
 
 export const TalkBackground: React.FC<{backgroundImg: string}> = ({
 	backgroundImg,

--- a/remotion/compositions/templates/talk/TalkSpeaker.tsx
+++ b/remotion/compositions/templates/talk/TalkSpeaker.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
-import {AvatarWithCaption} from '../../../design/molecules/AvatarWithCaption';
-import {Title} from '../../../design/atoms/Title';
+
 import {spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
+import {Title} from '../../../design/atoms/Title';
+import {AvatarWithCaption} from '../../../design/molecules/AvatarWithCaption';
 
 export const TalkSpeaker: React.FC<{
 	speakerPicture?: string;

--- a/remotion/compositions/templates/talk/Talks.composition.tsx
+++ b/remotion/compositions/templates/talk/Talks.composition.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
+
 import {Composition, Folder, staticFile} from 'remotion';
-import {Talk} from './Talk';
+
 import {TalkBranded} from './branded/TalkBranded';
+import {Talk} from './Talk';
 
 export const TalksComposition: React.FC = () => {
 	const startingDate = new Date(2023, 3, 18, 13);

--- a/remotion/compositions/templates/talk/branded/BrandedDetails.tsx
+++ b/remotion/compositions/templates/talk/branded/BrandedDetails.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
-import {spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
 import {Icon} from '@iconify/react';
+import {spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
 import {Text} from '../../../../design/atoms/Text';
 
 const ReccuringDay: React.FC<{day: string}> = ({day}) => {

--- a/remotion/compositions/templates/talk/branded/BrandedLocation.tsx
+++ b/remotion/compositions/templates/talk/branded/BrandedLocation.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+
 import {spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
 import {IconWithCaption} from '../../../../design/molecules/IconWithCaption';
 
 export const BrandedLocation: React.FC<{

--- a/remotion/compositions/templates/talk/branded/BrandedLogo.tsx
+++ b/remotion/compositions/templates/talk/branded/BrandedLogo.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import {
 	AbsoluteFill,
 	Img,

--- a/remotion/compositions/templates/talk/branded/BrandedSpeaker.tsx
+++ b/remotion/compositions/templates/talk/branded/BrandedSpeaker.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {AvatarWithCaption} from '../../../../design/molecules/AvatarWithCaption';
+
 import {
 	AbsoluteFill,
 	interpolate,
@@ -7,7 +7,9 @@ import {
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
+
 import {BrandedSpeakerInfos} from './BrandedSpeakerInfos';
+import {AvatarWithCaption} from '../../../../design/molecules/AvatarWithCaption';
 
 export const BrandedSpeaker: React.FC<{
 	pictureUrl: string;

--- a/remotion/compositions/templates/talk/branded/BrandedSpeakerInfos.tsx
+++ b/remotion/compositions/templates/talk/branded/BrandedSpeakerInfos.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
+
+import {interpolate, spring, useCurrentFrame, useVideoConfig} from 'remotion';
+
 import {Text} from '../../../../design/atoms/Text';
 import {IconWithCaption} from '../../../../design/molecules/IconWithCaption';
-import {interpolate, spring, useCurrentFrame, useVideoConfig} from 'remotion';
 
 export const BrandedSpeakerInfos: React.FC<{
 	name: string;

--- a/remotion/compositions/templates/talk/branded/BrandedTitle.tsx
+++ b/remotion/compositions/templates/talk/branded/BrandedTitle.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Title} from '../../../../design/atoms/Title';
+
 import {
 	AbsoluteFill,
 	interpolate,
@@ -7,6 +7,8 @@ import {
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
+
+import {Title} from '../../../../design/atoms/Title';
 
 export const BrandedTitle: React.FC<{title: string}> = ({title}) => {
 	const frame = useCurrentFrame();

--- a/remotion/compositions/templates/talk/branded/TalkBranded.tsx
+++ b/remotion/compositions/templates/talk/branded/TalkBranded.tsx
@@ -1,14 +1,16 @@
 import React from 'react';
-import {AbsoluteFill, Sequence, staticFile} from 'remotion';
+
 import {loadFont} from '@remotion/google-fonts/OpenSans';
-import {BrandedTitle} from './BrandedTitle';
-import {BrandedDetails} from './BrandedDetails';
-import {BackgroundCircleNoise} from '../../../../design/atoms/BackgroundCircleNoise';
-import {BrandedLogo} from './BrandedLogo';
-import {BrandedSpeaker} from './BrandedSpeaker';
 import {format} from 'date-fns';
 import {fr} from 'date-fns/locale';
+import {AbsoluteFill, Sequence, staticFile} from 'remotion';
+
+import {BrandedDetails} from './BrandedDetails';
 import {BrandedLocation} from './BrandedLocation';
+import {BrandedLogo} from './BrandedLogo';
+import {BrandedSpeaker} from './BrandedSpeaker';
+import {BrandedTitle} from './BrandedTitle';
+import {BackgroundCircleNoise} from '../../../../design/atoms/BackgroundCircleNoise';
 
 const {fontFamily} = loadFont();
 

--- a/remotion/design/atoms/Atoms.composition.tsx
+++ b/remotion/design/atoms/Atoms.composition.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
+
 import {Composition, Folder, staticFile} from 'remotion';
+
 import {Avatar} from './Avatar';
-import {EventLogo} from './EventLogo';
-import {Title} from './Title';
-import {BackgroundFiller} from './BackgroundFiller';
-import {Text} from './Text';
-import {BackgroundTriangle} from './BackgroundTriangle';
 import {BackgroundCircleNoise} from './BackgroundCircleNoise';
+import {BackgroundFiller} from './BackgroundFiller';
+import {BackgroundTriangle} from './BackgroundTriangle';
+import {EventLogo} from './EventLogo';
+import {Text} from './Text';
+import {Title} from './Title';
 
 export const AtomsComposition: React.FC = () => {
 	return (

--- a/remotion/design/atoms/Avatar.tsx
+++ b/remotion/design/atoms/Avatar.tsx
@@ -1,4 +1,5 @@
 import {CSSProperties} from 'react';
+
 import {Img, staticFile} from 'remotion';
 
 export const Avatar: React.FC<{

--- a/remotion/design/atoms/BackgroundCircleNoise.tsx
+++ b/remotion/design/atoms/BackgroundCircleNoise.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import {noise3D} from '@remotion/noise';
 import {interpolate, useCurrentFrame, useVideoConfig} from 'remotion';
 

--- a/remotion/design/atoms/BackgroundFiller.tsx
+++ b/remotion/design/atoms/BackgroundFiller.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import {Img} from 'remotion';
 
 export const BackgroundFiller: React.FC<{

--- a/remotion/design/atoms/EventLogo.tsx
+++ b/remotion/design/atoms/EventLogo.tsx
@@ -1,4 +1,5 @@
 import {CSSProperties} from 'react';
+
 import {Img, staticFile} from 'remotion';
 
 export type EventLogoProps = {

--- a/remotion/design/atoms/LottieAsset.tsx
+++ b/remotion/design/atoms/LottieAsset.tsx
@@ -1,7 +1,9 @@
-import {Lottie} from '@remotion/lottie';
-import {useLottie} from '../../hooks/useLottie';
-import {AbsoluteFill} from 'remotion';
 import {CSSProperties} from 'react';
+
+import {Lottie} from '@remotion/lottie';
+import {AbsoluteFill} from 'remotion';
+
+import {useLottie} from '../../hooks/useLottie';
 
 export const LottieAsset: React.FC<{
 	assetLink?: string;

--- a/remotion/design/atoms/Text.tsx
+++ b/remotion/design/atoms/Text.tsx
@@ -1,4 +1,5 @@
 import React, {ReactNode} from 'react';
+
 import {useSelectedFont} from '../../../src/app/hooks/useSelectedFont';
 
 export const Text: React.FC<{

--- a/remotion/design/atoms/Title.tsx
+++ b/remotion/design/atoms/Title.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+
 import {Text} from './Text';
 
 export const Title: React.FC<{

--- a/remotion/design/molecules/AvatarWithCaption.tsx
+++ b/remotion/design/molecules/AvatarWithCaption.tsx
@@ -1,4 +1,5 @@
 import React, {ReactNode} from 'react';
+
 import {Avatar} from '../atoms/Avatar';
 import {Text} from '../atoms/Text';
 

--- a/remotion/design/molecules/IconWithCaption.tsx
+++ b/remotion/design/molecules/IconWithCaption.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
+
 import {Icon} from '@iconify/react';
+
 import {Text} from '../atoms/Text';
 
 export const IconWithCaption: React.FC<{

--- a/remotion/design/molecules/Molecules.composition.tsx
+++ b/remotion/design/molecules/Molecules.composition.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
+
 import {Composition, Folder} from 'remotion';
+
 import {AvatarWithCaption} from './AvatarWithCaption';
-import {TalkDetails} from './TalkDetails';
 import {IconWithCaption} from './IconWithCaption';
+import {TalkDetails} from './TalkDetails';
 
 export const MoleculesComposition: React.FC = () => {
 	return (

--- a/remotion/hooks/useLottie.tsx
+++ b/remotion/hooks/useLottie.tsx
@@ -1,6 +1,7 @@
 import {useEffect, useState} from 'react';
-import {continueRender, delayRender} from 'remotion';
+
 import {LottieAnimationData} from '@remotion/lottie';
+import {continueRender, delayRender} from 'remotion';
 
 export const useLottie = (
 	icon: undefined | string

--- a/remotion/index.tsx
+++ b/remotion/index.tsx
@@ -2,6 +2,7 @@
 // npx remotion render <entry-file> HelloWorld out/video.mp4
 
 import {registerRoot} from 'remotion';
+
 import {RemotionVideo} from './Video';
 
 registerRoot(RemotionVideo);

--- a/src/app/Code.tsx
+++ b/src/app/Code.tsx
@@ -1,5 +1,7 @@
 import {MouseEvent, useCallback} from 'react';
+
 import va from '@vercel/analytics';
+
 import {ReplayProps} from '../../app/templates/replay/page';
 import {TalkBrandedProps} from '../../remotion/compositions/templates/talk/branded/TalkBranded';
 import {DefaultProps} from '../../remotion/types/defaultProps.types';

--- a/src/app/CopyUrlButton.tsx
+++ b/src/app/CopyUrlButton.tsx
@@ -1,6 +1,8 @@
 import React, {useCallback, useState} from 'react';
-import {QueryParams, formatUrlWithQuery} from './utils/formatUrlWithQuery';
+
 import {usePathname} from 'next/navigation';
+
+import {QueryParams, formatUrlWithQuery} from './utils/formatUrlWithQuery';
 
 export const CopyUrlButton: React.FC<{urlParameters: QueryParams}> = ({
 	urlParameters,

--- a/src/app/Footer.tsx
+++ b/src/app/Footer.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 
 import {Logo} from './Logo';
 import {PoweredByVercel} from './PoweredByVercel';
-import {SwitchThemeButtons} from './SwitchThemeButtons';
 import styles from '../../styles/app/layout/footer.module.css';
 
 export const Footer = () => {

--- a/src/app/Footer.tsx
+++ b/src/app/Footer.tsx
@@ -1,7 +1,9 @@
-import styles from '../../styles/app/layout/footer.module.css';
 import React from 'react';
+
 import {Logo} from './Logo';
 import {PoweredByVercel} from './PoweredByVercel';
+import {SwitchThemeButtons} from './SwitchThemeButtons';
+import styles from '../../styles/app/layout/footer.module.css';
 
 export const Footer = () => {
 	return (

--- a/src/app/LayerByMode.tsx
+++ b/src/app/LayerByMode.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
+
 import {LayerMode} from './types/layerMode.types';
-import {LayerTwoSpeaker} from '../../remotion/compositions/templates/layers/LayerTwoSpeaker';
 import {LayerFullScreen} from '../../remotion/compositions/templates/layers/LayerFullScreen';
 import {LayerOneSpeaker} from '../../remotion/compositions/templates/layers/LayerOneSpeaker';
+import {LayerTwoSpeaker} from '../../remotion/compositions/templates/layers/LayerTwoSpeaker';
 
 type LayerByModeProps = {
 	mode: LayerMode;

--- a/src/app/PoweredByVercel.tsx
+++ b/src/app/PoweredByVercel.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import {staticFile} from 'remotion';
 import Image from 'next/image';
+import {staticFile} from 'remotion';
+
 import {useSelectedTheme} from './hooks/useSelectedTheme';
 
 export const PoweredByVercel = () => {

--- a/src/app/RootLayout.tsx
+++ b/src/app/RootLayout.tsx
@@ -1,12 +1,14 @@
 import '../../styles/globals.css';
-import {Analytics} from '@vercel/analytics/react';
 
 import {ReactNode} from 'react';
-import {FontProvider} from '../context/FontContext';
-import {Footer} from './Footer';
-import {CustomThemeProvider} from '../context/CustomThemeProvider';
+
+import {Analytics} from '@vercel/analytics/react';
+
 import {Sidebar} from './components/sidebar/Sidebar';
+import {Footer} from './Footer';
 import styles from '../../styles/app/layout/main.module.css';
+import {CustomThemeProvider} from '../context/CustomThemeProvider';
+import {FontProvider} from '../context/FontContext';
 
 export default function RootLayout({children}: {children: ReactNode}) {
 	return (

--- a/src/app/SwitchThemeButtons.tsx
+++ b/src/app/SwitchThemeButtons.tsx
@@ -1,8 +1,8 @@
 'use client';
 
+import {useSelectedTheme} from './hooks/useSelectedTheme';
 import {ThemeRadioButton} from './ThemeRadioButton';
 import styles from '../../styles/app/common/themeRadioGroup.module.css';
-import {useSelectedTheme} from './hooks/useSelectedTheme';
 
 export const SwitchThemeButtons = () => {
 	const {systemTheme, selectedTheme, setSelectedTheme} = useSelectedTheme();

--- a/src/app/ThemeRadioButton.tsx
+++ b/src/app/ThemeRadioButton.tsx
@@ -1,4 +1,5 @@
 import {Icon} from '@iconify/react';
+
 import {SelectedThemeTypes} from './hooks/useSelectedTheme';
 import styles from '../../styles/app/common/themeRadioGroup.module.css';
 

--- a/src/app/components/sidebar/ActiveLink.tsx
+++ b/src/app/components/sidebar/ActiveLink.tsx
@@ -1,8 +1,10 @@
 'use client';
 
-import styles from '../../../../styles/app/components/sidebar/activeLink.module.css';
-import {usePathname} from 'next/navigation';
 import {ReactNode} from 'react';
+
+import {usePathname} from 'next/navigation';
+
+import styles from '../../../../styles/app/components/sidebar/activeLink.module.css';
 
 export const ActiveLink: React.FC<{
 	src: string;

--- a/src/app/components/sidebar/CategoryLink.tsx
+++ b/src/app/components/sidebar/CategoryLink.tsx
@@ -11,8 +11,6 @@ import {
 	CompositionType,
 } from '../../../data/config/sideBarConfig';
 
-
-
 export const CategoryLink: React.FC<
 	categoryProps & {
 		categoryRoute: string;

--- a/src/app/components/sidebar/CategoryLink.tsx
+++ b/src/app/components/sidebar/CategoryLink.tsx
@@ -1,14 +1,17 @@
 'use client';
 
+import {Icon} from '@iconify/react';
+import {usePathname} from 'next/navigation';
+
+import {ActiveLink} from './ActiveLink';
+import {CompositionThumbnail} from './CompositionThumbnail';
 import styles from '../../../../styles/app/components/sidebar/nav.module.css';
 import {
 	categoryProps,
 	CompositionType,
 } from '../../../data/config/sideBarConfig';
-import {ActiveLink} from './ActiveLink';
-import {usePathname} from 'next/navigation';
-import {CompositionThumbnail} from './CompositionThumbnail';
-import {Icon} from '@iconify/react';
+
+
 
 export const CategoryLink: React.FC<
 	categoryProps & {

--- a/src/app/components/sidebar/CompositionThumbnail.tsx
+++ b/src/app/components/sidebar/CompositionThumbnail.tsx
@@ -1,7 +1,8 @@
-import {useCompositionConfig} from '../../hooks/useCompositionConfig';
 import {Thumbnail} from '@remotion/player';
-import {CompositionType} from '../../../data/config/sideBarConfig';
+
 import styles from '../../../../styles/app/components/sidebar/activeLink.module.css';
+import {CompositionType} from '../../../data/config/sideBarConfig';
+import {useCompositionConfig} from '../../hooks/useCompositionConfig';
 
 type CompositionThumbnailProps = {
 	compositionType: CompositionType;

--- a/src/app/components/sidebar/Footer.tsx
+++ b/src/app/components/sidebar/Footer.tsx
@@ -1,6 +1,7 @@
+import {Icon} from '@iconify/react';
+
 import styles from '../../../../styles/app/components/sidebar/sidebar.module.css';
 import {SwitchThemeButtons} from '../../SwitchThemeButtons';
-import {Icon} from '@iconify/react';
 
 export const Footer: React.FC<{expanded: boolean}> = ({expanded}) => {
 	return (

--- a/src/app/components/sidebar/Header.tsx
+++ b/src/app/components/sidebar/Header.tsx
@@ -1,6 +1,7 @@
+import {MuseoModerno} from 'next/font/google';
+
 import styles from '../../../../styles/app/components/sidebar/sidebar.module.css';
 import {Logo} from '../../Logo';
-import {MuseoModerno} from 'next/font/google';
 
 const wormarkFont = MuseoModerno({
 	weight: '900',

--- a/src/app/components/sidebar/Nav.tsx
+++ b/src/app/components/sidebar/Nav.tsx
@@ -11,8 +11,6 @@ import {
 	sideBarNavConfig,
 } from '../../../data/config/sideBarConfig';
 
-
-
 export const Nav: React.FC<{expanded: boolean}> = ({expanded}) => {
 	const [openedNavDetails, setOpenedNavDetails] = useState<string | null>(null);
 

--- a/src/app/components/sidebar/Nav.tsx
+++ b/src/app/components/sidebar/Nav.tsx
@@ -1,14 +1,17 @@
 'use client';
 
+import {useState} from 'react';
+
+import {ActiveLink} from './ActiveLink';
+import {NavDetails} from './NavDetails';
+import {TopLevelContent} from './TopLevelContent';
 import styles from '../../../../styles/app/components/sidebar/nav.module.css';
 import {
 	CompositionType,
 	sideBarNavConfig,
 } from '../../../data/config/sideBarConfig';
-import {ActiveLink} from './ActiveLink';
-import {NavDetails} from './NavDetails';
-import {useState} from 'react';
-import {TopLevelContent} from './TopLevelContent';
+
+
 
 export const Nav: React.FC<{expanded: boolean}> = ({expanded}) => {
 	const [openedNavDetails, setOpenedNavDetails] = useState<string | null>(null);

--- a/src/app/components/sidebar/NavDetails.tsx
+++ b/src/app/components/sidebar/NavDetails.tsx
@@ -1,18 +1,20 @@
 'use client';
 
-import styles from '../../../../styles/app/components/sidebar/nav.module.css';
+import {useEffect, useState} from 'react';
+
 import {Icon} from '@iconify/react';
-import {CategoryLink} from './CategoryLink';
-import {ActiveLink} from './ActiveLink';
-import {CompositionThumbnail} from './CompositionThumbnail';
 import {usePathname} from 'next/navigation';
+
+import {ActiveLink} from './ActiveLink';
+import {CategoryLink} from './CategoryLink';
+import {CompositionThumbnail} from './CompositionThumbnail';
+import {TopLevelContent} from './TopLevelContent';
+import styles from '../../../../styles/app/components/sidebar/nav.module.css';
 import {
 	categoryProps,
 	CompositionType,
 	videoProps,
 } from '../../../data/config/sideBarConfig';
-import {useEffect, useState} from 'react';
-import {TopLevelContent} from './TopLevelContent';
 
 type NavDetailsProps = {
 	videoType: CompositionType;

--- a/src/app/components/sidebar/Sidebar.tsx
+++ b/src/app/components/sidebar/Sidebar.tsx
@@ -1,11 +1,13 @@
 'use client';
 
-import styles from '../../../../styles/app/components/sidebar/sidebar.module.css';
-import {Nav} from './Nav';
 import React, {useState} from 'react';
-import {Header} from './Header';
-import {Footer} from './Footer';
+
 import {Icon} from '@iconify/react';
+
+import {Footer} from './Footer';
+import {Header} from './Header';
+import {Nav} from './Nav';
+import styles from '../../../../styles/app/components/sidebar/sidebar.module.css';
 
 export const Sidebar = () => {
 	const [expanded, setExpanded] = useState<boolean>(true);

--- a/src/app/forms/FontPicker.tsx
+++ b/src/app/forms/FontPicker.tsx
@@ -1,7 +1,8 @@
 import {ChangeEventHandler} from 'react';
+
+import styles from '../../../styles/app/common/inputs.module.css';
 import {top250} from '../../data/fonts';
 import {useSelectedFont} from '../hooks/useSelectedFont';
-import styles from '../../../styles/app/common/inputs.module.css';
 
 export const FontPicker: React.FC<{
 	label: string;

--- a/src/app/forms/input.tsx
+++ b/src/app/forms/input.tsx
@@ -1,4 +1,5 @@
 import React, {FormEvent, ReactNode} from 'react';
+
 import styles from '../../../styles/app/common/inputs.module.css';
 
 export const Form: React.FC<{children: ReactNode}> = ({children}) => {

--- a/src/app/forms/inputDate.tsx
+++ b/src/app/forms/inputDate.tsx
@@ -1,5 +1,7 @@
 import {FormEvent} from 'react';
+
 import {format} from 'date-fns';
+
 import styles from '../../../styles/app/common/inputs.module.css';
 
 export const InputDate: React.FC<{

--- a/src/app/forms/selectInput.tsx
+++ b/src/app/forms/selectInput.tsx
@@ -1,4 +1,5 @@
 import React, {ChangeEventHandler} from 'react';
+
 import styles from '../../../styles/app/common/inputs.module.css';
 
 export interface SelectInputProps {

--- a/src/app/hooks/useInputChange.ts
+++ b/src/app/hooks/useInputChange.ts
@@ -1,4 +1,5 @@
 import {FormEvent, useCallback, useState} from 'react';
+
 import {useSearchParams} from 'next/navigation';
 
 export const useInputChange = <ValueType extends string | undefined>(

--- a/src/app/hooks/useInputDateChange.ts
+++ b/src/app/hooks/useInputDateChange.ts
@@ -1,4 +1,5 @@
 import {FormEvent, useCallback, useState} from 'react';
+
 import {useSearchParams} from 'next/navigation';
 
 export const useInputDateChange = <ValueType extends Date | undefined>(

--- a/src/app/hooks/useSelectedFont.ts
+++ b/src/app/hooks/useSelectedFont.ts
@@ -1,7 +1,9 @@
 import {useContext, useEffect} from 'react';
-import {loadGoogleFont} from '../utils/loadFont';
-import {FontContext} from '../../context/FontContext';
+
 import {useSearchParams} from 'next/navigation';
+
+import {FontContext} from '../../context/FontContext';
+import {loadGoogleFont} from '../utils/loadFont';
 
 export const useSelectedFont = () => {
 	const {selectedFont, setSelectedFont} = useContext(FontContext);

--- a/src/app/hooks/useSelectedTheme.ts
+++ b/src/app/hooks/useSelectedTheme.ts
@@ -1,4 +1,5 @@
 import {useEffect, useState} from 'react';
+
 import {useTheme} from 'next-themes';
 
 export type SelectedThemeTypes = 'dark' | 'light' | 'system';

--- a/src/app/utils/loadFont.ts
+++ b/src/app/utils/loadFont.ts
@@ -1,5 +1,6 @@
-import {top250} from '../../data/fonts';
 import {continueRender, delayRender, staticFile} from 'remotion';
+
+import {top250} from '../../data/fonts';
 
 type RemotionFont = {
 	loadFont: () => void;

--- a/src/context/CustomThemeProvider.tsx
+++ b/src/context/CustomThemeProvider.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import {ReactNode} from 'react';
+
 import {ThemeProvider} from 'next-themes';
 
 export const CustomThemeProvider = ({children}: {children: ReactNode}) => {

--- a/src/data/config/compositionsConfig.ts
+++ b/src/data/config/compositionsConfig.ts
@@ -1,21 +1,20 @@
-import {ReplayProps} from '../../../app/templates/replay/page';
-import {TalkBrandedProps} from '../../../remotion/compositions/templates/talk/branded/TalkBranded';
-
-import {TalkConfig} from './templates/talkConfig';
-import {TalkBrandedConfig} from './templates/talkBrandedConfig';
-import {LayersConfig} from './templates/layersConfig';
-import {SponsorConfig} from './templates/sponsorConfig';
-import {EventConfig} from './templates/eventConfig';
-import {MeetupConfig} from './templates/meetupConfig';
-import {SilhouetteConfig} from './templates/silhouetteConfig';
+import {AlpesCraftConfig} from './showcases/alpesCraftConfig';
+import {CampingDesSpeakersConfig} from './showcases/campingDesSpeakersConfig';
 import {DevoxxConfig} from './showcases/devoxxConfig';
 import {MixitConfig} from './showcases/mixitConfig';
 import {SnowcampConfig} from './showcases/snowcampConfig';
 import {TouraineTechConfig} from './showcases/touraineTechConfig';
 import {VeryTechTripConfig} from './showcases/veryTechTripConfig';
-import {AlpesCraftConfig} from './showcases/alpesCraftConfig';
-import {CampingDesSpeakersConfig} from './showcases/campingDesSpeakersConfig';
 import {VolcampConfig} from './showcases/volcampConfig';
+import {EventConfig} from './templates/eventConfig';
+import {LayersConfig} from './templates/layersConfig';
+import {MeetupConfig} from './templates/meetupConfig';
+import {SilhouetteConfig} from './templates/silhouetteConfig';
+import {SponsorConfig} from './templates/sponsorConfig';
+import {TalkBrandedConfig} from './templates/talkBrandedConfig';
+import {TalkConfig} from './templates/talkConfig';
+import {ReplayProps} from '../../../app/templates/replay/page';
+import {TalkBrandedProps} from '../../../remotion/compositions/templates/talk/branded/TalkBranded';
 import {DefaultProps} from '../../../remotion/types/defaultProps.types';
 
 export type CompositionProps = {

--- a/src/data/config/showcases/alpesCraftConfig.ts
+++ b/src/data/config/showcases/alpesCraftConfig.ts
@@ -1,6 +1,6 @@
-import {CompositionProps} from '../compositionsConfig';
-import {defaultTalkValues} from '../../defaultValues';
 import {AlpesCraft} from '../../../../remotion/compositions/showcases/alpescraft/AlpesCraft';
+import {defaultTalkValues} from '../../defaultValues';
+import {CompositionProps} from '../compositionsConfig';
 
 export const AlpesCraftConfig: CompositionProps = {
 	compositionName: 'AlpesCraft',

--- a/src/data/config/showcases/campingDesSpeakersConfig.ts
+++ b/src/data/config/showcases/campingDesSpeakersConfig.ts
@@ -1,7 +1,9 @@
-import {CompositionProps} from '../compositionsConfig';
-import {defaultTalkValues} from '../../defaultValues';
-import {CampingDesSpeakers} from '../../../../remotion/compositions/showcases/campingDesSpeakers/CampingDesSpeakers';
 import _ = require('lodash');
+
+import {CampingDesSpeakers} from '../../../../remotion/compositions/showcases/campingDesSpeakers/CampingDesSpeakers';
+import {defaultTalkValues} from '../../defaultValues';
+import {CompositionProps} from '../compositionsConfig';
+
 
 export const CampingDesSpeakersConfig: CompositionProps = {
 	compositionName: 'CampingDesSpeakers',

--- a/src/data/config/showcases/campingDesSpeakersConfig.ts
+++ b/src/data/config/showcases/campingDesSpeakersConfig.ts
@@ -4,7 +4,6 @@ import {CampingDesSpeakers} from '../../../../remotion/compositions/showcases/ca
 import {defaultTalkValues} from '../../defaultValues';
 import {CompositionProps} from '../compositionsConfig';
 
-
 export const CampingDesSpeakersConfig: CompositionProps = {
 	compositionName: 'CampingDesSpeakers',
 	component: CampingDesSpeakers,

--- a/src/data/config/showcases/devoxxConfig.ts
+++ b/src/data/config/showcases/devoxxConfig.ts
@@ -1,6 +1,6 @@
-import {CompositionProps} from '../compositionsConfig';
 import {Devoxx2023} from '../../../../remotion/compositions/showcases/devoxx/Devoxx2023';
 import {defaultTalkValues} from '../../defaultValues';
+import {CompositionProps} from '../compositionsConfig';
 
 export const DevoxxConfig: CompositionProps = {
 	compositionName: 'Devoxx2023',

--- a/src/data/config/showcases/mixitConfig.ts
+++ b/src/data/config/showcases/mixitConfig.ts
@@ -1,6 +1,6 @@
-import {CompositionProps} from '../compositionsConfig';
-import {defaultTalkValues} from '../../defaultValues';
 import {MixitIntroTalk} from '../../../../remotion/compositions/showcases/mixit/MixitIntroTalk';
+import {defaultTalkValues} from '../../defaultValues';
+import {CompositionProps} from '../compositionsConfig';
 
 export const MixitConfig: CompositionProps = {
 	compositionName: 'Mixit2023',

--- a/src/data/config/showcases/snowcampConfig.ts
+++ b/src/data/config/showcases/snowcampConfig.ts
@@ -1,6 +1,6 @@
-import {CompositionProps} from '../compositionsConfig';
-import {defaultTalkValues} from '../../defaultValues';
 import {Snowcamp} from '../../../../remotion/compositions/showcases/snowcamp/Snowcamp';
+import {defaultTalkValues} from '../../defaultValues';
+import {CompositionProps} from '../compositionsConfig';
 
 export const SnowcampConfig: CompositionProps = {
 	compositionName: 'Snowcamp',

--- a/src/data/config/showcases/touraineTechConfig.ts
+++ b/src/data/config/showcases/touraineTechConfig.ts
@@ -1,6 +1,6 @@
-import {CompositionProps} from '../compositionsConfig';
-import {defaultTalkValues} from '../../defaultValues';
 import {TouraineTech2023} from '../../../../remotion/compositions/showcases/touraineTech/TouraineTech2023';
+import {defaultTalkValues} from '../../defaultValues';
+import {CompositionProps} from '../compositionsConfig';
 
 export const TouraineTechConfig: CompositionProps = {
 	compositionName: 'TouraineTech2023',

--- a/src/data/config/showcases/veryTechTripConfig.ts
+++ b/src/data/config/showcases/veryTechTripConfig.ts
@@ -1,6 +1,6 @@
-import {CompositionProps} from '../compositionsConfig';
-import {defaultTalkValues} from '../../defaultValues';
 import {VeryTechTrip} from '../../../../remotion/compositions/showcases/veryTechTrip/VeryTechTrip';
+import {defaultTalkValues} from '../../defaultValues';
+import {CompositionProps} from '../compositionsConfig';
 
 export const VeryTechTripConfig: CompositionProps = {
 	compositionName: 'VeryTechTrip',

--- a/src/data/config/showcases/volcampConfig.ts
+++ b/src/data/config/showcases/volcampConfig.ts
@@ -1,7 +1,9 @@
-import {CompositionProps} from '../compositionsConfig';
-import {defaultTalkValues} from '../../defaultValues';
-import {Volcamp} from '../../../../remotion/compositions/showcases/volcamp/Volcamp';
 import _ = require('lodash');
+
+import {Volcamp} from '../../../../remotion/compositions/showcases/volcamp/Volcamp';
+import {defaultTalkValues} from '../../defaultValues';
+import {CompositionProps} from '../compositionsConfig';
+
 
 export const VolcampConfig: CompositionProps = {
 	compositionName: 'Volcamp2023',

--- a/src/data/config/showcases/volcampConfig.ts
+++ b/src/data/config/showcases/volcampConfig.ts
@@ -4,7 +4,6 @@ import {Volcamp} from '../../../../remotion/compositions/showcases/volcamp/Volca
 import {defaultTalkValues} from '../../defaultValues';
 import {CompositionProps} from '../compositionsConfig';
 
-
 export const VolcampConfig: CompositionProps = {
 	compositionName: 'Volcamp2023',
 	component: Volcamp,

--- a/src/data/config/templates/eventConfig.ts
+++ b/src/data/config/templates/eventConfig.ts
@@ -1,5 +1,5 @@
-import {CompositionProps} from '../compositionsConfig';
 import {Event} from '../../../../remotion/compositions/templates/event/Event';
+import {CompositionProps} from '../compositionsConfig';
 
 export const EventConfig: CompositionProps = {
 	compositionName: 'Event',

--- a/src/data/config/templates/meetupConfig.ts
+++ b/src/data/config/templates/meetupConfig.ts
@@ -1,6 +1,7 @@
-import {CompositionProps} from '../compositionsConfig';
-import {Meetup} from '../../../../remotion/compositions/templates/meetup/Meetup';
 import {staticFile} from 'remotion';
+
+import {Meetup} from '../../../../remotion/compositions/templates/meetup/Meetup';
+import {CompositionProps} from '../compositionsConfig';
 
 export const MeetupConfig: CompositionProps = {
 	compositionName: 'Meetup',

--- a/src/data/config/templates/silhouetteConfig.ts
+++ b/src/data/config/templates/silhouetteConfig.ts
@@ -1,6 +1,7 @@
-import {CompositionProps} from '../compositionsConfig';
-import {Silhouette} from '../../../../remotion/compositions/templates/silhouette/Silhouette';
 import {staticFile} from 'remotion';
+
+import {Silhouette} from '../../../../remotion/compositions/templates/silhouette/Silhouette';
+import {CompositionProps} from '../compositionsConfig';
 
 export const SilhouetteConfig: CompositionProps = {
 	compositionName: 'Silhouette',

--- a/src/data/config/templates/sponsorConfig.ts
+++ b/src/data/config/templates/sponsorConfig.ts
@@ -1,5 +1,5 @@
-import {CompositionProps} from '../compositionsConfig';
 import {Sponsor} from '../../../../remotion/compositions/templates/sponsor/Sponsor';
+import {CompositionProps} from '../compositionsConfig';
 
 export const SponsorConfig: CompositionProps = {
 	compositionName: 'Sponsor',

--- a/src/data/config/templates/talkBrandedConfig.ts
+++ b/src/data/config/templates/talkBrandedConfig.ts
@@ -1,5 +1,5 @@
-import {CompositionProps} from '../compositionsConfig';
 import {TalkBranded} from '../../../../remotion/compositions/templates/talk/branded/TalkBranded';
+import {CompositionProps} from '../compositionsConfig';
 
 export const TalkBrandedConfig: CompositionProps = {
 	compositionName: 'TalkBranded',

--- a/src/data/config/templates/talkConfig.ts
+++ b/src/data/config/templates/talkConfig.ts
@@ -1,5 +1,6 @@
-import {Talk} from '../../../../remotion/compositions/templates/talk/Talk';
 import {staticFile} from 'remotion';
+
+import {Talk} from '../../../../remotion/compositions/templates/talk/Talk';
 import {CompositionProps} from '../compositionsConfig';
 
 export const TalkConfig: CompositionProps = {


### PR DESCRIPTION
## 🤔 Why do you want to make those changes?

Our imports are really messy, it can be good to have an eslint rule to organise them

## 🧑‍🔬 How did you make them?

I added the module eslint-import-plugin and fix all the files with `pnpm lint --fix`

## 🧪 How to check them?

- check the tests
- read the code
- check the preview
