### PR TITLE
feat(app): saving sidebar folded preference

### DIFF
--- a/__test__/app/sidebar.test.tsx
+++ b/__test__/app/sidebar.test.tsx
@@ -143,4 +143,17 @@ describe('<Sidebar />', () => {
 		expect(video).not.toBeVisible();
 		expect(secondVideo).toBeVisible();
 	});
+
+	it('should save fold preferences', async () => {
+		const user = userEvent.setup();
+		const foldButton = screen.getByRole('button', {
+			name: 'foldButton',
+		});
+
+		await user.click(foldButton);
+		expect(window.localStorage.getItem('expanded')).toEqual('false');
+
+		await user.click(foldButton);
+		expect(window.localStorage.getItem('expanded')).toEqual('true');
+	});
 });

--- a/__test__/app/sidebar.test.tsx
+++ b/__test__/app/sidebar.test.tsx
@@ -31,6 +31,10 @@ describe('<Sidebar />', () => {
 		);
 	});
 
+	afterEach(() => {
+		window.localStorage.clear();
+	});
+
 	it('should render the component', () => {
 		const sidebar = screen.getByRole('region', {
 			name: 'sidebar',
@@ -108,13 +112,13 @@ describe('<Sidebar />', () => {
 		expect(contributingText).not.toBeVisible();
 	});
 
-	it('should alternate display ditails when folded', async () => {
+	it('should alternate display details when folded', async () => {
 		const user = userEvent.setup();
 		const foldButton = screen.getByRole('button', {
 			name: 'foldButton',
 		});
 		const details = screen.getAllByRole('group');
-		const fisrtLink = details[0];
+		const firstLink = details[0];
 		const secondLink = details[2];
 
 		const video = screen.getByRole('link', {
@@ -129,7 +133,7 @@ describe('<Sidebar />', () => {
 		expect(video).not.toBeVisible();
 		expect(secondVideo).not.toBeVisible();
 
-		await user.click(fisrtLink);
+		await user.click(firstLink);
 
 		expect(video).toBeVisible();
 		expect(secondVideo).not.toBeVisible();

--- a/src/app/hooks/useSidebarPreferences.ts
+++ b/src/app/hooks/useSidebarPreferences.ts
@@ -1,18 +1,19 @@
 import {useEffect, useState} from 'react';
 
 export const useSidebarPreferences = () => {
-	const [folded, setFolded] = useState<boolean>(false);
+	const [expanded, setExpanded] = useState<boolean>(true);
 
 	useEffect(() => {
-		const foldedPreferencesString = localStorage.getItem('folded');
-		const foldedPreferences = foldedPreferencesString === 'true' ? true : false;
-		foldedPreferences && setFolded(foldedPreferences);
+		const expandedPreferencesString = localStorage.getItem('expanded');
+		const expandedPreferences =
+			expandedPreferencesString === 'false' ? false : true;
+		setExpanded(expandedPreferences);
 	}, []);
 
-	const handleFold = (value: boolean) => {
-		setFolded(value);
-		localStorage.setItem('folded', `${value}`);
+	const handleExpand = (value: boolean) => {
+		setExpanded(value);
+		localStorage.setItem('expanded', `${value}`);
 	};
 
-	return {folded, setFolded: handleFold};
+	return {expanded, setExpanded: handleExpand};
 };

--- a/src/app/hooks/useSidebarPreferences.ts
+++ b/src/app/hooks/useSidebarPreferences.ts
@@ -5,9 +5,10 @@ export const useSidebarPreferences = () => {
 
 	useEffect(() => {
 		const expandedPreferencesString = localStorage.getItem('expanded');
-		const expandedPreferences =
-			expandedPreferencesString === 'false' ? false : true;
-		setExpanded(expandedPreferences);
+		if (expandedPreferencesString) {
+			const expandedPreferences = JSON.parse(expandedPreferencesString);
+			setExpanded(expandedPreferences);
+		}
 	}, []);
 
 	const handleExpand = (value: boolean) => {

--- a/src/app/hooks/useSidebarPreferences.ts
+++ b/src/app/hooks/useSidebarPreferences.ts
@@ -4,10 +4,9 @@ export const useSidebarPreferences = () => {
 	const [folded, setFolded] = useState<boolean>(false);
 
 	useEffect(() => {
-		const foldedPreferenciesString = localStorage.getItem('folded');
-		const foldedPreferencies =
-			foldedPreferenciesString === 'true' ? true : false;
-		foldedPreferencies && setFolded(foldedPreferencies);
+		const foldedPreferencesString = localStorage.getItem('folded');
+		const foldedPreferences = foldedPreferencesString === 'true' ? true : false;
+		foldedPreferences && setFolded(foldedPreferences);
 	}, []);
 
 	const handleFold = (value: boolean) => {

--- a/src/app/hooks/useSidebarPreferences.ts
+++ b/src/app/hooks/useSidebarPreferences.ts
@@ -1,0 +1,19 @@
+import {useEffect, useState} from 'react';
+
+export const useSidebarPreferences = () => {
+	const [folded, setFolded] = useState<boolean>(false);
+
+	useEffect(() => {
+		const foldedPreferenciesString = localStorage.getItem('folded');
+		const foldedPreferencies =
+			foldedPreferenciesString === 'true' ? true : false;
+		foldedPreferencies && setFolded(foldedPreferencies);
+	}, []);
+
+	const handleFold = (value: boolean) => {
+		setFolded(value);
+		localStorage.setItem('folded', `${value}`);
+	};
+
+	return {folded, setFolded: handleFold};
+};

--- a/src/context/SidebarContext.tsx
+++ b/src/context/SidebarContext.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import {createContext, ReactNode, useState} from 'react';
+import {createContext, ReactNode} from 'react';
+
+import {useSidebarPreferences} from '../app/hooks/useSidebarPreferences';
 
 type SidebarContextProps = {
 	expanded: boolean;
@@ -17,7 +19,7 @@ interface SidebarProviderProps {
 }
 
 export const SidebarProvider: React.FC<SidebarProviderProps> = ({children}) => {
-	const [expanded, setExpanded] = useState<boolean>(true);
+	const {expanded, setExpanded} = useSidebarPreferences();
 
 	return (
 		<SidebarContext.Provider value={{expanded, setExpanded}}>


### PR DESCRIPTION
## 🤔 Why do you want to make those changes?

We want to save the preferences of the user about the sidebar

## 🧑‍🔬 How did you make them?

I created a hook that get and set a local storage variable to save the fold value of the sidebar

## 🧪 How to check them?

- Check the code
- Check the preview
