### PR TITLE
feat(devfest): poc for remotion animation in fullscreen via url

### DIFF
--- a/app/screens/layers/[mode]/page.tsx
+++ b/app/screens/layers/[mode]/page.tsx
@@ -18,11 +18,13 @@ export default function LayerScreenMode({params}: {params: {mode: string}}) {
 
 	return (
 		<Player
+			autoPlay
+			loop
 			style={{
 				width: '100%',
 				aspectRatio: '16 / 9',
 			}}
-			durationInFrames={1}
+			durationInFrames={140}
 			compositionWidth={1920}
 			compositionHeight={1080}
 			fps={30}

--- a/app/templates/layers/page.tsx
+++ b/app/templates/layers/page.tsx
@@ -15,10 +15,10 @@ export default function LayersPage() {
 	const [mode, setMode] = useInputChange<LayerMode>('one');
 	const [title, setTitle] = useInputChange<string>('Shortvid.io 🎬');
 	const [sponsor, setSponsor] = useInputChange<string>(
-		'https://secure.meetupstatic.com/photos/event/2/8/7/a/600_464230362.jpeg',
+		'https://devfest2023.gdgnantes.com/images/logo_transparent.svg',
 	);
 	const [primaryColor, setPrimaryColor] = useInputChange<string>('#323330');
-	const [secondaryColor, setSecondaryColor] = useInputChange<string>('#efdb4f');
+	const [secondaryColor, setSecondaryColor] = useInputChange<string>('#E9764F');
 	const [decoration, setDecoration] = useInputChange<string>(
 		'https://user-images.githubusercontent.com/60877626/232909816-ca4e61c0-acb2-469b-95dc-beed0cb6b482.png',
 	);
@@ -47,13 +47,15 @@ export default function LayersPage() {
 	return (
 		<div className="flex flex-col pb-4 justify-center items-center md:flex-row md:items-start">
 			<Player
+				autoPlay
+				controls
 				loop
 				className="shrink-0 shadow-lg"
 				style={{
-					width: '350px',
+					width: '800px',
 					aspectRatio: '16 / 9',
 				}}
-				durationInFrames={1}
+				durationInFrames={140}
 				compositionWidth={1920}
 				compositionHeight={1080}
 				fps={30}

--- a/remotion/compositions/templates/layers/LayerOneSpeaker.tsx
+++ b/remotion/compositions/templates/layers/LayerOneSpeaker.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {AbsoluteFill, Img} from 'remotion';
 
 import {BackgroundTriangle} from '../../../design/atoms/BackgroundTriangle';
-import {GreenScreen} from '../../showcases/lyonJS/GreenScreen';
+import {TalkBranded, TalkBrandedProps} from '../talk/branded/TalkBranded';
 
 import {DefaultLayerProps} from './layers.types';
 import {LayerTitle} from './LayerTitle';
@@ -34,19 +34,71 @@ export const LayerOneSpeaker: React.FC<DefaultLayerProps> = ({
 					src={decorationUrl}
 				/>
 			)}
-			<GreenScreen style={{width: '75%'}} />
-			<GreenScreen
+			<div
+				style={{
+					width: '75%',
+					height: '80%',
+					position: 'absolute',
+					top: 50,
+					left: 50,
+					overflow: 'hidden',
+					border: '10px solid white',
+				}}
+			>
+				<TalkBranded
+					backgroundColor="#F2B167"
+					title="Road to Certification : Cloud Architect en 🇫🇷 avec 250+ inscrits et 40 vouchers"
+					startingDate={new Date('2023-04-19T11:00:00.000Z')}
+					endingDate={new Date('2023-05-23T11:45:00.000Z')}
+					recurringDay="Mardi"
+					location="Avec 9 communautés GDG 💚"
+					logoUrl="https://user-images.githubusercontent.com/72607059/233019842-047a34a4-77c1-4200-adc8-c70a6daf8f10.svg"
+					speaker={
+						{
+							name: 'Julien Landuré',
+							company: 'GDG Cloud Nantes & Zenika',
+							pictureUrl:
+								'https://pbs.twimg.com/profile_images/892750804104380418/J_YkAC_C_400x400.jpg',
+						} as TalkBrandedProps['speaker']
+					}
+				/>
+			</div>
+			<div
 				style={{
 					width: '30%',
+					height: '30%',
 					position: 'absolute',
-					bottom: 0,
-					right: 0,
+					bottom: 50,
+					right: 50,
+					overflow: 'hidden',
+					border: '10px solid white',
 				}}
-			/>
+			>
+				<TalkBranded
+					backgroundColor="#F2B167"
+					title="Road to Certification : Cloud Architect en 🇫🇷 avec 250+ inscrits et 40 vouchers"
+					startingDate={new Date('2023-04-19T11:00:00.000Z')}
+					endingDate={new Date('2023-05-23T11:45:00.000Z')}
+					recurringDay="Mardi"
+					location="Avec 9 communautés GDG 💚"
+					logoUrl="https://user-images.githubusercontent.com/72607059/233019842-047a34a4-77c1-4200-adc8-c70a6daf8f10.svg"
+					speaker={
+						{
+							name: 'Julien Landuré',
+							company: 'GDG Cloud Nantes & Zenika',
+							pictureUrl:
+								'https://pbs.twimg.com/profile_images/892750804104380418/J_YkAC_C_400x400.jpg',
+						} as TalkBrandedProps['speaker']
+					}
+				/>
+			</div>
 			{title && (
 				<LayerTitle
 					title={title}
 					style={{
+						position: 'absolute',
+						top: 980,
+						height: 'min-content',
 						width: 'calc(70% - 30px)',
 					}}
 				/>

--- a/remotion/compositions/templates/layers/Layers.composition.tsx
+++ b/remotion/compositions/templates/layers/Layers.composition.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Folder, Still} from 'remotion';
+import {Composition, Folder, Still} from 'remotion';
 
 import {LayerFullScreen} from './LayerFullScreen';
 import {LayerOneSpeaker} from './LayerOneSpeaker';
@@ -22,14 +22,18 @@ export const LayersComposition: React.FC = () => {
 					decorationUrl: defaultDecorationUrl,
 				}}
 			/>
-			<Still
+			<Composition
 				id="LayerOneSpeaker"
 				component={LayerOneSpeaker}
 				width={1920}
 				height={1080}
+				fps={30}
+				durationInFrames={140}
 				defaultProps={{
 					title: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit',
-					sponsorLogoUrl: defaultSponsorLogoUrl,
+					secondaryColor: '#E9764F',
+					sponsorLogoUrl:
+						'https://devfest2023.gdgnantes.com/images/logo_transparent.svg',
 					decorationUrl: defaultDecorationUrl,
 				}}
 			/>


### PR DESCRIPTION
## 🤔 Why do you want to make those changes?

For a test display on the screens of the cité des congrès we need to have a url on which we can display a Remotion video. 
ℹ️ To test the performance and display, there are several animations on the screen. The templates that have been used will of course be modified later, it's just for testing purposes

## 🧑‍🔬 How did you make them?

For this poque I've replaced the use of `Still` in the `OneSpeaker` layer so that I can use a Remotion video instead. And I replaced the `GreenScreen` with the `TalkBranded` video remotion template

## 🧪 How to check them?

🔗 Link to full screen video for display on screens : https://shortvid-git-poc-devfest-nantes-lyonjs.vercel.app/screens/layers/one?title=Shortvid.io%20%F0%9F%8E%AC&sponsor=https://devfest2023.gdgnantes.com/images/logo_transparent.svg&primaryColor=%23323330&secondaryColor=%23E9764F&decoration=https:/user-images.githubusercontent.com/60877626/232909816-ca4e61c0-acb2-469b-95dc-beed0cb6b482.png

🔗 Link to the customisation form : https://shortvid-git-poc-devfest-nantes-lyonjs.vercel.app/templates/layers
ℹ️ Although not all the fields in the video are customisable in this poc
