### PR TITLE
refactor(resize): avoid useEffect dependencies change on every render

### DIFF
--- a/src/app/components/sidebar/ResizeWrapper.tsx
+++ b/src/app/components/sidebar/ResizeWrapper.tsx
@@ -31,10 +31,6 @@ export const ResizeWrapper: React.FC<{
 		setIsResizing(true);
 	};
 
-	const stopResize = () => {
-		setIsResizing(false);
-	};
-
 	const resize = useCallback(
 		(event: MouseEvent) => {
 			if (isResizing) {
@@ -52,6 +48,10 @@ export const ResizeWrapper: React.FC<{
 	);
 
 	useEffect(() => {
+		const stopResize = () => {
+			setIsResizing(false);
+		};
+
 		window.addEventListener('mousemove', resize);
 		window.addEventListener('mouseup', stopResize);
 
@@ -59,7 +59,7 @@ export const ResizeWrapper: React.FC<{
 			window.removeEventListener('mousemove', resize);
 			window.removeEventListener('mouseup', stopResize);
 		};
-	}, [resize, stopResize]);
+	}, [resize]);
 
 	return (
 		<div


### PR DESCRIPTION
## 🤔 Why do you want to make those changes?

The `stopResize` function makes the dependencies of useEffect Hook change on every render.

## 🧑‍🔬 How did you make them?

Move the function inside the useEffect callback.

## 🧪 How to check them?

Just check the app and try to resize the sidebar 😊
