### PR TITLE
feat(zod): adding zod schema on talk branded compositions

### DIFF
--- a/app/templates/talks/talkBranded/page.tsx
+++ b/app/templates/talks/talkBranded/page.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import {Player} from '@remotion/player';
+import {z} from 'zod';
 
 import {TalkBranded} from '../../../../remotion/compositions/templates/talk/branded/TalkBranded';
+import {TalkBrandedSchema} from '../../../../remotion/compositions/templates/talk/talks.types';
 import {Code} from '../../../../src/app/Code';
 import {ResizeWrapper} from '../../../../src/app/components/sidebar/ResizeWrapper';
 import {Sidebar} from '../../../../src/app/components/sidebar/Sidebar';
@@ -10,7 +12,6 @@ import {ColorInput} from '../../../../src/app/forms/colorInput';
 import {Form, FormConfigProps} from '../../../../src/app/forms/Form';
 import {Input} from '../../../../src/app/forms/input';
 import {InputDate} from '../../../../src/app/forms/inputDate';
-import {SelectInput} from '../../../../src/app/forms/selectInput';
 import {useInputChange} from '../../../../src/app/hooks/useInputChange';
 import {useInputDateChange} from '../../../../src/app/hooks/useInputDateChange';
 import {encodeObjectValues} from '../../../../src/app/utils/encodeObjectValues';
@@ -18,8 +19,14 @@ import {encodeObjectValues} from '../../../../src/app/utils/encodeObjectValues';
 import styles from '../../../../styles/app/layout/main.module.css';
 
 export default function BrandedTalkPage() {
+	const defaultDate: Date = new Date();
+	defaultDate.setSeconds(0, 0);
+
+	const logoGDG =
+		'https://user-images.githubusercontent.com/72607059/233019842-047a34a4-77c1-4200-adc8-c70a6daf8f10.svg';
+
 	const [backgroundColor, setBackgroundColor] = useInputChange<string>(
-		'#EA4335',
+		'#086fda',
 		'backgroundColor',
 	);
 	const [title, setTitle] = useInputChange<string>('Example', 'title');
@@ -38,38 +45,20 @@ export default function BrandedTalkPage() {
 		undefined,
 		'speakersJob',
 	);
-
-	const logoGDG =
-		'https://user-images.githubusercontent.com/72607059/233019842-047a34a4-77c1-4200-adc8-c70a6daf8f10.svg';
 	const [logoUrl, setLogoUrl] = useInputChange<string>(logoGDG, 'logoUrl');
-	const [recurringDay, setRecurringDay] = useInputChange<string | undefined>(
-		undefined,
-		'recurringDay',
-	);
 	const [location, setLocation] = useInputChange<string | undefined>(
 		undefined,
 		'location',
 	);
-
-	const today = new Date();
-	// We set the seconds to 0 to handle a server/client diff
-	today.setSeconds(0, 0);
-
 	const [startingDate, setStartingDate] = useInputDateChange<Date>(
-		today,
+		defaultDate,
 		'startingDate',
 	);
-	const [endingDate, setEndingDate] = useInputDateChange<Date | undefined>(
-		undefined,
-		'endingDate',
-	);
 
-	const props = {
+	const props: z.infer<typeof TalkBrandedSchema> = {
 		backgroundColor,
 		title,
 		startingDate,
-		endingDate,
-		recurringDay,
 		location,
 		logoUrl,
 		speaker: {
@@ -84,8 +73,6 @@ export default function BrandedTalkPage() {
 		backgroundColor,
 		title,
 		startingDate,
-		endingDate,
-		recurringDay,
 		location,
 		logoUrl,
 		speakerPicture,
@@ -98,7 +85,7 @@ export default function BrandedTalkPage() {
 		backgroundColor: {
 			state: backgroundColor,
 			setState: setBackgroundColor,
-			label: 'Background Color (optional)',
+			label: 'Background Color',
 			component: ColorInput,
 		},
 		title: {
@@ -112,19 +99,6 @@ export default function BrandedTalkPage() {
 			setState: setStartingDate,
 			label: 'Starting Date',
 			component: InputDate,
-		},
-		endingDate: {
-			state: endingDate,
-			setState: setEndingDate,
-			label: 'Ending Date (optional)',
-			component: InputDate,
-		},
-		recurringDay: {
-			state: recurringDay,
-			setState: setRecurringDay,
-			label: 'Recurring day',
-			component: SelectInput,
-			options: [undefined, 'lundi', 'mardi', 'mercredi', 'jeudi', 'vendredi'],
 		},
 		location: {
 			state: location,

--- a/remotion/compositions/templates/talk/Talks.composition.tsx
+++ b/remotion/compositions/templates/talk/Talks.composition.tsx
@@ -3,10 +3,10 @@ import {Composition, Folder, staticFile} from 'remotion';
 
 import {TalkBranded} from './branded/TalkBranded';
 import {Talk} from './Talk';
+import {TalkBrandedSchema} from './talks.types';
 
 export const TalksComposition: React.FC = () => {
 	const startingDate = new Date(2023, 3, 18, 13);
-	const endingDate = new Date(2023, 4, 23, 13, 45);
 
 	return (
 		<Folder name="Talks">
@@ -44,11 +44,11 @@ export const TalksComposition: React.FC = () => {
 				id="TalkBranded"
 				fps={30}
 				durationInFrames={140}
+				schema={TalkBrandedSchema}
 				defaultProps={{
+					backgroundColor: '#086fda',
 					title: 'Certification “Google Cloud Architect”',
 					startingDate,
-					endingDate,
-					recurringDay: 'mardi',
 					location: '5 Place Jules Ferry, 69006.',
 					logoUrl:
 						'https://user-images.githubusercontent.com/72607059/233019842-047a34a4-77c1-4200-adc8-c70a6daf8f10.svg',

--- a/remotion/compositions/templates/talk/branded/BrandedDetails.tsx
+++ b/remotion/compositions/templates/talk/branded/BrandedDetails.tsx
@@ -1,48 +1,27 @@
-import React from 'react';
 import {Icon} from '@iconify/react';
+import {format} from 'date-fns';
+import {fr} from 'date-fns/locale';
 import {spring, useCurrentFrame, useVideoConfig} from 'remotion';
 
 import {Text} from '../../../../design/atoms/Text';
 
-const ReccuringDay: React.FC<{day: string}> = ({day}) => {
-	return (
-		<span>
-			Tout les <b>{day}</b>.{' '}
-		</span>
-	);
-};
-
-const TimeRange: React.FC<{
-	startingTime: string;
-	endingTime: string;
-}> = ({startingTime, endingTime}) => {
-	return (
-		<span>
-			De{' '}
-			<b>
-				{startingTime} à {endingTime}.
-			</b>
-		</span>
-	);
-};
-
-export const BrandedDetails: React.FC<{
-	startingDate: string;
-	endingDate?: string;
-	reccuringDay?: string;
-	startingTime: string;
-	endingTime?: string;
+type BrandedDetailsProps = {
+	startingDateTime: Date;
 	location?: string;
-}> = ({
-	startingDate,
-	endingDate,
-	reccuringDay,
-	startingTime,
-	endingTime,
+};
+
+export const BrandedDetails = ({
+	startingDateTime,
 	location,
-}) => {
+}: BrandedDetailsProps) => {
 	const frame = useCurrentFrame();
 	const {fps} = useVideoConfig();
+
+	const formatedStartingDate = new Date(startingDateTime);
+	const startingDate = format(formatedStartingDate, 'dd MMMM yyyy', {
+		locale: fr,
+	});
+	const startingTime = format(formatedStartingDate, "HH 'h' mm");
 
 	const slideIn = spring({
 		frame,
@@ -83,7 +62,7 @@ export const BrandedDetails: React.FC<{
 						paddingBottom: '5px',
 					}}
 				>
-					{endingDate ? `Du ${startingDate} au ${endingDate}` : startingDate}
+					{startingDate}
 				</Text>
 				<Text
 					style={{
@@ -92,20 +71,10 @@ export const BrandedDetails: React.FC<{
 						display: 'block',
 						textAlign: 'left',
 						fontSize: '1.18rem',
+						fontWeight: 'bold',
 					}}
 				>
-					{reccuringDay && <ReccuringDay day={reccuringDay} />}
-					{endingTime ? (
-						<TimeRange startingTime={startingTime} endingTime={endingTime} />
-					) : (
-						<span
-							style={{
-								fontWeight: 'bold',
-							}}
-						>
-							{startingTime}
-						</span>
-					)}
+					{startingTime}
 				</Text>
 			</div>
 		</div>

--- a/remotion/compositions/templates/talk/branded/BrandedLocation.tsx
+++ b/remotion/compositions/templates/talk/branded/BrandedLocation.tsx
@@ -1,11 +1,12 @@
-import React from 'react';
 import {spring, useCurrentFrame, useVideoConfig} from 'remotion';
 
 import {IconWithCaption} from '../../../../design/molecules/IconWithCaption';
 
-export const BrandedLocation: React.FC<{
+type BrandedLocationProps = {
 	location: string;
-}> = ({location}) => {
+};
+
+export const BrandedLocation = ({location}: BrandedLocationProps) => {
 	const frame = useCurrentFrame();
 	const {fps} = useVideoConfig();
 

--- a/remotion/compositions/templates/talk/branded/BrandedLogo.tsx
+++ b/remotion/compositions/templates/talk/branded/BrandedLogo.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
 	AbsoluteFill,
 	Img,
@@ -7,10 +6,12 @@ import {
 	useVideoConfig,
 } from 'remotion';
 
-export const BrandedLogo: React.FC<{
+type BrandedLogoProps = {
 	logoUrl: string;
-	borderColor?: string;
-}> = ({logoUrl, borderColor = '#EA4335'}) => {
+	borderColor: string;
+};
+
+export const BrandedLogo = ({logoUrl, borderColor}: BrandedLogoProps) => {
 	const frame = useCurrentFrame();
 	const {fps} = useVideoConfig();
 

--- a/remotion/compositions/templates/talk/branded/BrandedSpeaker.tsx
+++ b/remotion/compositions/templates/talk/branded/BrandedSpeaker.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
 	AbsoluteFill,
 	interpolate,
@@ -11,12 +10,19 @@ import {AvatarWithCaption} from '../../../../design/molecules/AvatarWithCaption'
 
 import {BrandedSpeakerInfos} from './BrandedSpeakerInfos';
 
-export const BrandedSpeaker: React.FC<{
+type BrandedSpeakerProps = {
 	pictureUrl: string;
 	name: string;
 	company?: string;
 	job?: string;
-}> = ({pictureUrl, name, company, job}) => {
+};
+
+export const BrandedSpeaker = ({
+	pictureUrl,
+	name,
+	company,
+	job,
+}: BrandedSpeakerProps) => {
 	const frame = useCurrentFrame();
 	const {fps} = useVideoConfig();
 

--- a/remotion/compositions/templates/talk/branded/BrandedSpeakerInfos.tsx
+++ b/remotion/compositions/templates/talk/branded/BrandedSpeakerInfos.tsx
@@ -1,14 +1,19 @@
-import React from 'react';
 import {interpolate, spring, useCurrentFrame, useVideoConfig} from 'remotion';
 
 import {Text} from '../../../../design/atoms/Text';
 import {IconWithCaption} from '../../../../design/molecules/IconWithCaption';
 
-export const BrandedSpeakerInfos: React.FC<{
+type BrandedSpeakerInfosProps = {
 	name: string;
 	company?: string;
 	job?: string;
-}> = ({name, company, job}) => {
+};
+
+export const BrandedSpeakerInfos = ({
+	name,
+	company,
+	job,
+}: BrandedSpeakerInfosProps) => {
 	const frame = useCurrentFrame();
 	const {fps} = useVideoConfig();
 	const opacity = spring({

--- a/remotion/compositions/templates/talk/branded/BrandedTitle.tsx
+++ b/remotion/compositions/templates/talk/branded/BrandedTitle.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import {
 	AbsoluteFill,
 	interpolate,
@@ -9,7 +8,11 @@ import {
 
 import {Title} from '../../../../design/atoms/Title';
 
-export const BrandedTitle: React.FC<{title: string}> = ({title}) => {
+type BrandedTitleProps = {
+	title: string;
+};
+
+export const BrandedTitle = ({title}: BrandedTitleProps) => {
 	const frame = useCurrentFrame();
 	const {fps} = useVideoConfig();
 

--- a/remotion/compositions/templates/talk/branded/TalkBranded.tsx
+++ b/remotion/compositions/templates/talk/branded/TalkBranded.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import {loadFont} from '@remotion/google-fonts/OpenSans';
-import {format} from 'date-fns';
-import {fr} from 'date-fns/locale';
 import {AbsoluteFill, Sequence, staticFile} from 'remotion';
+import {z} from 'zod';
 
 import {BackgroundCircleNoise} from '../../../../design/atoms/BackgroundCircleNoise';
+import {TalkBrandedSchema} from '../talks.types';
 
 import {BrandedDetails} from './BrandedDetails';
 import {BrandedLocation} from './BrandedLocation';
@@ -14,81 +14,46 @@ import {BrandedTitle} from './BrandedTitle';
 
 const {fontFamily} = loadFont();
 
-export type TalkBrandedProps = {
-	backgroundColor?: string;
-	title: string;
-	startingDate: Date;
-	endingDate?: Date;
-	recurringDay?: string;
-	location?: string;
-	logoUrl: string;
-	speaker: {pictureUrl: string; name: string; company?: string; job?: string};
-};
-
-export const TalkBranded: React.FC<TalkBrandedProps> = ({
-	backgroundColor = '#EA4335',
+export const TalkBranded = ({
+	backgroundColor,
 	title,
 	startingDate,
-	endingDate,
-	recurringDay,
 	location,
 	logoUrl,
 	speaker,
-}) => {
-	const formatedStartingDate = new Date(startingDate);
-	const startingDay = format(formatedStartingDate, 'dd MMMM yyyy', {
-		locale: fr,
-	});
-	const startingTime = format(formatedStartingDate, "HH 'h' mm");
-
-	const formatedEndingDate = endingDate && new Date(endingDate);
-	const endingDay =
-		formatedEndingDate &&
-		format(formatedEndingDate, 'dd MMMM yyyy', {locale: fr});
-	const endingTime =
-		formatedEndingDate && format(formatedEndingDate, "HH 'h' mm");
-
-	return (
-		<AbsoluteFill
-			style={{
-				backgroundColor,
-				fontFamily,
-			}}
-		>
-			<Sequence name="Noise Background">
-				<BackgroundCircleNoise speed={0.01} circleRadius={5} maxOffset={20} />
+}: z.infer<typeof TalkBrandedSchema>) => (
+	<AbsoluteFill
+		style={{
+			backgroundColor,
+			fontFamily,
+		}}
+	>
+		<Sequence name="Noise Background">
+			<BackgroundCircleNoise speed={0.01} circleRadius={5} maxOffset={20} />
+		</Sequence>
+		<Sequence name="Logo">
+			<BrandedLogo logoUrl={logoUrl} borderColor={backgroundColor} />
+		</Sequence>
+		<Sequence name="Speaker" from={10}>
+			<BrandedSpeaker
+				pictureUrl={
+					speaker.pictureUrl || staticFile('/images/common/defaultAvatar.svg')
+				}
+				name={speaker.name}
+				company={speaker.company}
+				job={speaker.job}
+			/>
+		</Sequence>
+		<Sequence name="Title" from={40}>
+			<BrandedTitle title={title} />
+		</Sequence>
+		<Sequence name="Details" from={50}>
+			<BrandedDetails startingDateTime={startingDate} location={location} />
+		</Sequence>
+		{location && (
+			<Sequence name="Location" from={55}>
+				<BrandedLocation location={location} />
 			</Sequence>
-			<Sequence name="Logo">
-				<BrandedLogo logoUrl={logoUrl} borderColor={backgroundColor} />
-			</Sequence>
-			<Sequence name="Speaker" from={10}>
-				<BrandedSpeaker
-					pictureUrl={
-						speaker.pictureUrl || staticFile('/images/common/defaultAvatar.svg')
-					}
-					name={speaker.name}
-					company={speaker.company}
-					job={speaker.job}
-				/>
-			</Sequence>
-			<Sequence name="Title" from={40}>
-				<BrandedTitle title={title} />
-			</Sequence>
-			<Sequence name="Details" from={50}>
-				<BrandedDetails
-					startingDate={startingDay}
-					endingDate={endingDay}
-					reccuringDay={recurringDay}
-					startingTime={startingTime}
-					endingTime={endingTime}
-					location={location}
-				/>
-			</Sequence>
-			{location && (
-				<Sequence name="Location" from={55}>
-					<BrandedLocation location={location} />
-				</Sequence>
-			)}
-		</AbsoluteFill>
-	);
-};
+		)}
+	</AbsoluteFill>
+);

--- a/remotion/compositions/templates/talk/talks.types.ts
+++ b/remotion/compositions/templates/talk/talks.types.ts
@@ -1,0 +1,16 @@
+import {zColor} from '@remotion/zod-types';
+import {z} from 'zod';
+
+export const TalkBrandedSchema = z.object({
+	backgroundColor: zColor(),
+	title: z.string(),
+	startingDate: z.date(),
+	location: z.string().optional(),
+	logoUrl: z.string(),
+	speaker: z.object({
+		pictureUrl: z.string(),
+		name: z.string(),
+		company: z.string().optional(),
+		job: z.string().optional(),
+	}),
+});

--- a/src/app/types/template.types.ts
+++ b/src/app/types/template.types.ts
@@ -9,8 +9,8 @@ import {CarouselType} from '../../../remotion/compositions/templates/carousel/Ca
 import {SilhouetteProps} from '../../../remotion/compositions/templates/silhouette/Silhouette';
 import {SponsorSchema} from '../../../remotion/compositions/templates/sponsors/sponsors.types';
 import {SpotlightNewSponsornProps} from '../../../remotion/compositions/templates/sponsors/spotlightNewSponsor/SpotlightNewSponsor';
-import {TalkBrandedProps} from '../../../remotion/compositions/templates/talk/branded/TalkBranded';
 import {TalkProps} from '../../../remotion/compositions/templates/talk/Talk';
+import {TalkBrandedSchema} from '../../../remotion/compositions/templates/talk/talks.types';
 import {DefaultProps} from '../../../remotion/types/defaultProps.types';
 import {LayerByModeProps} from '../LayerByMode';
 
@@ -19,7 +19,7 @@ export type DefaultPropsTypes =
 	| DefaultProps
 	| ReplayProps
 	| TalkProps
-	| TalkBrandedProps
+	| z.infer<typeof TalkBrandedSchema>
 	| AlpesCraftProps
 	| VolcampProps
 	| CampingDesSpeakersProps
@@ -34,7 +34,7 @@ export type TemplateTypes =
 	| React.FC<DefaultProps>
 	| React.FC<ReplayProps>
 	| React.FC<TalkProps>
-	| React.FC<TalkBrandedProps>
+	| React.FC<z.infer<typeof TalkBrandedSchema>>
 	| React.FC<AlpesCraftProps>
 	| React.FC<VolcampProps>
 	| React.FC<CampingDesSpeakersProps>

--- a/src/data/config/compositionsConfig.ts
+++ b/src/data/config/compositionsConfig.ts
@@ -1,5 +1,7 @@
+import {z} from 'zod';
+
 import {ReplayProps} from '../../../app/templates/replays/replay/page';
-import {TalkBrandedProps} from '../../../remotion/compositions/templates/talk/branded/TalkBranded';
+import {TalkBrandedSchema} from '../../../remotion/compositions/templates/talk/talks.types';
 import {DefaultProps} from '../../../remotion/types/defaultProps.types';
 import {TemplateTypes} from '../../app/types/template.types';
 
@@ -35,7 +37,7 @@ export type CompositionProps = {
 		| {[key: string]: string | undefined}
 		| DefaultProps
 		| ReplayProps
-		| TalkBrandedProps;
+		| z.infer<typeof TalkBrandedSchema>;
 };
 
 type CompositionsConfigProps = {

--- a/src/data/config/templates/talkBrandedConfig.ts
+++ b/src/data/config/templates/talkBrandedConfig.ts
@@ -8,11 +8,9 @@ export const TalkBrandedConfig: CompositionProps = {
 	height: 720,
 	durationInFrames: 140,
 	defaultProps: {
-		backgroundColor: '#EA4335',
+		backgroundColor: '#086fda',
 		title: 'Certification “Google Cloud Architect”',
 		startingDate: new Date(2023, 3, 18, 13),
-		endingDate: new Date(2023, 4, 23, 13, 45),
-		recurringDay: 'mardi',
 		location: '5 Place Jules Ferry, 69006.',
 		logoUrl:
 			'https://user-images.githubusercontent.com/72607059/233019842-047a34a4-77c1-4200-adc8-c70a6daf8f10.svg',


### PR DESCRIPTION
## 🤔 Why do you want to make those changes?

In order to have cleaner types for our compositions and use Remotion's new editing features, we want to use Zod

## 🧑‍🔬 How did you make them?

- [x] Update and clean components
	- [x] Simplify the composition to make it more generic
	- [x] Remove end Date & recurring day
	- [x] Fix default props issue where props were not taking into account
- [x] Create Zod schema on `remotion/compositions/templates/talk/talks.types.ts`

## 🧪 How to check them?

Check the preview that the talk branded video is working as it was before + clone the projet to check that the remotion editor is working or check the video :

https://github.com/lyonjs/shortvid.io/assets/60877626/225a2257-f08b-482d-8e4e-bc7df6cf67bd

ℹ️ There's a warning about saving default props, I've spotted the problem and I'm going to create an issue directly in remotion.
