### PR TITLE
feat(server): add frame/still rendering in the API

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -115,7 +115,7 @@ app.post('/frame/:compositionId/:frameId', async (req, res) => {
 			output: finalOutput,
 			inputProps,
 			composition: composition,
-			frame: parseInt(frameId),
+			frame: parseInt(frameId, 10),
 		});
 
 		sendFile(finalOutput);


### PR DESCRIPTION
## 🤔 Why do you want to make those changes?

Be able to render still image from a composition 

## 🧑‍🔬 How did you make them?

Add a new route for frame/still rendering, based on the video output

## 🧪 How to check them?

```curl -X POST http://localhost:8000/frame/Talk/-1 --output toto1.png```
