### PR TITLE
fix(#976): add default Img src for speaker picture

### DIFF
--- a/remotion/compositions/showcases/campingDesSpeakers/components/Speakers.tsx
+++ b/remotion/compositions/showcases/campingDesSpeakers/components/Speakers.tsx
@@ -3,7 +3,6 @@ import {
 	AbsoluteFill,
 	interpolate,
 	spring,
-	staticFile,
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
@@ -59,12 +58,7 @@ export const Speakers: React.FC<{speakers: Speaker[]}> = ({speakers}) => {
 						}}
 					>
 						<AvatarWithCaption
-							avatarPictureUrl={
-								speaker.picture ||
-								staticFile(
-									'images/showcases/campingDesSpeakers/campingDesSpeakersLogo.png',
-								)
-							}
+							avatarPictureUrl={speaker.picture}
 							avatarStyle={{
 								width: 180,
 								height: 180,

--- a/remotion/compositions/showcases/devfestLille/Speakers.tsx
+++ b/remotion/compositions/showcases/devfestLille/Speakers.tsx
@@ -3,7 +3,6 @@ import {
 	AbsoluteFill,
 	interpolate,
 	spring,
-	staticFile,
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
@@ -58,12 +57,7 @@ export const Speakers: React.FC<{speakers: Speaker[]}> = ({speakers}) => {
 						}}
 					>
 						<AvatarWithCaption
-							avatarPictureUrl={
-								speaker.picture ||
-								staticFile(
-									'images/showcases/campingDesSpeakers/campingDesSpeakersLogo.png',
-								)
-							}
+							avatarPictureUrl={speaker.picture}
 							avatarStyle={{
 								width: 180,
 								height: 180,

--- a/remotion/compositions/showcases/devfestNantes/Speakers.tsx
+++ b/remotion/compositions/showcases/devfestNantes/Speakers.tsx
@@ -3,7 +3,6 @@ import {
 	AbsoluteFill,
 	interpolate,
 	spring,
-	staticFile,
 	useCurrentFrame,
 	useVideoConfig,
 } from 'remotion';
@@ -58,12 +57,7 @@ export const Speakers: React.FC<{speakers: Speaker[]}> = ({speakers}) => {
 						}}
 					>
 						<AvatarWithCaption
-							avatarPictureUrl={
-								speaker.picture ||
-								staticFile(
-									'images/showcases/campingDesSpeakers/campingDesSpeakersLogo.png',
-								)
-							}
+							avatarPictureUrl={speaker.picture}
 							avatarStyle={{
 								width: 180,
 								height: 180,

--- a/remotion/compositions/showcases/volcamp/components/Speakers.tsx
+++ b/remotion/compositions/showcases/volcamp/components/Speakers.tsx
@@ -1,4 +1,10 @@
-import {Img, spring, useCurrentFrame, useVideoConfig} from 'remotion';
+import {
+	Img,
+	spring,
+	staticFile,
+	useCurrentFrame,
+	useVideoConfig,
+} from 'remotion';
 
 import {Text} from '../../../../design/atoms/Text';
 
@@ -102,7 +108,10 @@ export const Speakers: React.FC<speakerProps> = ({speakers}) => {
 								</span>
 							)}
 							<Img
-								src={speaker.picture}
+								src={
+									speaker.picture ||
+									staticFile('images/common/defaultAvatar.svg')
+								}
 								alt={`Picture of ${speaker.name}`}
 								width={130}
 								height={130}

--- a/remotion/design/molecules/AvatarWithCaption.tsx
+++ b/remotion/design/molecules/AvatarWithCaption.tsx
@@ -1,4 +1,5 @@
 import React, {ReactNode} from 'react';
+import {staticFile} from 'remotion';
 
 import {Avatar} from '../atoms/Avatar';
 import {Text} from '../atoms/Text';
@@ -35,7 +36,7 @@ export const AvatarWithCaption: React.FC<{
 					position: 'relative',
 					...avatarStyle,
 				}}
-				src={avatarPictureUrl}
+				src={avatarPictureUrl || staticFile('images/common/defaultAvatar.svg')}
 			/>
 			{!children && (
 				<Text


### PR DESCRIPTION
## 🤔 Why do you want to make those changes?

To prevent having an error when adding a new speaker without src image url when editing the video from the studio we have to set a default src

## 🧑‍🔬 How did you make them?

Adding a default src image

## 🧪 How to check them?

Check code
