### PR TITLE
fix(app): add type to input

### DIFF
--- a/app/templates/talks/talk/page.tsx
+++ b/app/templates/talks/talk/page.tsx
@@ -64,6 +64,7 @@ export default function TalkPage() {
 		},
 		titleSize: {
 			state: titleSize,
+			type: 'number',
 			setState: setTitleSize,
 			label: 'Title size',
 			component: Input,

--- a/src/app/forms/Form.tsx
+++ b/src/app/forms/Form.tsx
@@ -26,6 +26,7 @@ export type FormConfigProps = {
 		label: string;
 		component: FormInputTypes;
 		placeholder?: string;
+		type?: string;
 		options?: (string | undefined)[];
 	};
 };
@@ -63,6 +64,7 @@ export const Form: React.FC<{
 								label={value.label}
 								placeholder={value.placeholder}
 								options={value.options}
+								type={value.type}
 							/>
 						);
 					})}


### PR DESCRIPTION
## 🤔 Why do you want to make those changes?
![image](https://github.com/lyonjs/shortvid.io/assets/89846571/1a55ba03-34e9-46b1-a98e-4369d4c8308e)

 think fourth input should be as type of number because there user enter size of title, so that is why i wanted to change it to number

## 🧑‍🔬 How did you make them?

just by adding "type" to places where it needed

## 🧪 How to check them?
by going through templates/talks/talk



