### PR TITLE
feat(template/Talk): adding color picker on talk template

### DIFF
--- a/app/templates/talks/talk/page.tsx
+++ b/app/templates/talks/talk/page.tsx
@@ -29,7 +29,7 @@ export default function TalkPage() {
 	const [eventLogo, setEventLogo] = useInputChange<string>('', 'eventLogo');
 	const [titleSize, setTitleSize] = useInputChange<number>(50, 'titleSize');
 	const [backgroundImg, setBackgroundImg] = useInputChange<string | undefined>(
-		undefined,
+		'https://placehold.co/1200x1200',
 		'backgroundImg',
 	);
 	const [titleColor, setTitleColor] = useInputChange<string>(

--- a/app/templates/talks/talk/page.tsx
+++ b/app/templates/talks/talk/page.tsx
@@ -6,6 +6,7 @@ import {Talk} from '../../../../remotion/compositions/templates/talk/Talk';
 import {Code} from '../../../../src/app/Code';
 import {ResizeWrapper} from '../../../../src/app/components/sidebar/ResizeWrapper';
 import {Sidebar} from '../../../../src/app/components/sidebar/Sidebar';
+import {ColorInput} from '../../../../src/app/forms/colorInput';
 import {Form, FormConfigProps} from '../../../../src/app/forms/Form';
 import {Input} from '../../../../src/app/forms/input';
 import {useInputChange} from '../../../../src/app/hooks/useInputChange';
@@ -26,10 +27,14 @@ export default function TalkPage() {
 		'speakersNames',
 	);
 	const [eventLogo, setEventLogo] = useInputChange<string>('', 'eventLogo');
-	const [titleSize, setTitleSize] = useInputChange<string>('50', 'titleSize');
+	const [titleSize, setTitleSize] = useInputChange<number>(50, 'titleSize');
 	const [backgroundImg, setBackgroundImg] = useInputChange<string | undefined>(
 		undefined,
 		'backgroundImg',
+	);
+	const [titleColor, setTitleColor] = useInputChange<string>(
+		'#efdb50',
+		'titleColor',
 	);
 
 	const props = {
@@ -37,6 +42,7 @@ export default function TalkPage() {
 		speakersNames,
 		speakerPicture,
 		titleSize,
+		titleColor,
 		backgroundImg,
 		eventLogo,
 	};
@@ -61,6 +67,12 @@ export default function TalkPage() {
 			setState: setTalkTitle,
 			label: 'Title',
 			component: Input,
+		},
+		titleColor: {
+			state: titleColor,
+			setState: setTitleColor,
+			label: 'Title color',
+			component: ColorInput,
 		},
 		titleSize: {
 			state: titleSize,

--- a/remotion/compositions/templates/talk/SpeakerAndTitle.tsx
+++ b/remotion/compositions/templates/talk/SpeakerAndTitle.tsx
@@ -14,9 +14,10 @@ import {TalkSpeaker} from './TalkSpeaker';
 export const SpeakerAndTitle: React.FC<{
 	speakerPicture?: string;
 	speakersNames: string;
-	titleSize: string;
+	titleSize: number;
 	talkTitle: string;
-}> = ({speakerPicture, speakersNames, titleSize, talkTitle}) => {
+	titleColor: string;
+}> = ({speakerPicture, speakersNames, titleSize, talkTitle, titleColor}) => {
 	const frame = useCurrentFrame();
 	const {fps} = useVideoConfig();
 
@@ -44,7 +45,7 @@ export const SpeakerAndTitle: React.FC<{
 					speakersNames={speakersNames}
 					speakerNameStyle={{
 						width: '100%',
-						color: '#efdb50',
+						color: titleColor,
 						position: 'absolute',
 						fontSize: 70,
 						top: '55%',

--- a/remotion/compositions/templates/talk/Talk.tsx
+++ b/remotion/compositions/templates/talk/Talk.tsx
@@ -12,7 +12,8 @@ export type TalkProps = {
 	talkTitle: string;
 	backgroundImg?: string;
 	speakerPicture?: string;
-	titleSize?: string;
+	titleSize?: number;
+	titleColor?: string;
 };
 
 export const Talk: React.FC<TalkProps> = ({
@@ -20,7 +21,8 @@ export const Talk: React.FC<TalkProps> = ({
 	speakersNames,
 	talkTitle,
 	speakerPicture,
-	titleSize = '80',
+	titleSize = 80,
+	titleColor = '#efdb50',
 	backgroundImg = staticFile(
 		'/images/showcases/lyonjs/defaultBackgroundImage.jpeg',
 	),
@@ -40,6 +42,7 @@ export const Talk: React.FC<TalkProps> = ({
 					talkTitle={talkTitle}
 					speakerPicture={speakerPicture}
 					titleSize={titleSize}
+					titleColor={titleColor}
 				/>
 
 				<EventLogo

--- a/remotion/compositions/templates/talk/Talks.composition.tsx
+++ b/remotion/compositions/templates/talk/Talks.composition.tsx
@@ -3,7 +3,7 @@ import {Composition, Folder, staticFile} from 'remotion';
 
 import {TalkBranded} from './branded/TalkBranded';
 import {Talk} from './Talk';
-import {TalkBrandedSchema} from './talks.types';
+import {TalkBrandedSchema, TalkSchema} from './talks.types';
 
 export const TalksComposition: React.FC = () => {
 	const startingDate = new Date(2023, 3, 18, 13);
@@ -17,6 +17,7 @@ export const TalksComposition: React.FC = () => {
 				id="TalkWithPicture"
 				fps={30}
 				durationInFrames={120}
+				schema={TalkSchema}
 				defaultProps={{
 					speakersNames: 'John Doe',
 					talkTitle: 'Is JS an awesome programing language ?',
@@ -32,6 +33,7 @@ export const TalksComposition: React.FC = () => {
 				id="Talk"
 				fps={30}
 				durationInFrames={120}
+				schema={TalkSchema}
 				defaultProps={{
 					speakersNames: 'Foo bar',
 					talkTitle: 'Is JS an awesome programing language?',

--- a/remotion/compositions/templates/talk/talks.types.ts
+++ b/remotion/compositions/templates/talk/talks.types.ts
@@ -16,3 +16,13 @@ export const TalkBrandedSchema = z.object({
 	logoUrl: z.string(),
 	speakers: z.array(TalkBrandedSpeakerSchema),
 });
+
+export const TalkSchema = z.object({
+	eventLogo: z.string().optional(),
+	speakersNames: z.string(),
+	talkTitle: z.string(),
+	backgroundImg: z.string().optional(),
+	speakerPicture: z.string().optional(),
+	titleSize: z.number().optional(),
+	titleColor: zColor().optional(),
+});

--- a/src/app/forms/Form.tsx
+++ b/src/app/forms/Form.tsx
@@ -21,7 +21,7 @@ type FormInputTypes =
 
 export type FormConfigProps = {
 	[key: string]: {
-		state: string | Date | undefined;
+		state: string | Date | number | undefined;
 		setState: (event: FormEvent<HTMLInputElement | HTMLSelectElement>) => void;
 		label: string;
 		component: FormInputTypes;

--- a/src/app/hooks/useInputChange.ts
+++ b/src/app/hooks/useInputChange.ts
@@ -1,7 +1,7 @@
 import {FormEvent, useCallback, useState} from 'react';
 import {useSearchParams} from 'next/navigation';
 
-export const useInputChange = <ValueType extends string | undefined>(
+export const useInputChange = <ValueType extends string | number | undefined>(
 	defaultValue: ValueType,
 	query?: string,
 ) => {

--- a/src/data/config/compositionsConfig.ts
+++ b/src/data/config/compositionsConfig.ts
@@ -34,7 +34,7 @@ export type CompositionProps = {
 	frameForThumbnail?: number;
 	fps?: number;
 	defaultProps?:
-		| {[key: string]: string | undefined}
+		| {[key: string]: string | number | undefined}
 		| DefaultProps
 		| z.infer<typeof TalkBrandedSchema>;
 };

--- a/src/data/config/templates/talkConfig.ts
+++ b/src/data/config/templates/talkConfig.ts
@@ -17,6 +17,6 @@ export const TalkConfig: CompositionProps = {
 		backgroundImg:
 			'https://user-images.githubusercontent.com/6263857/188308094-03b94a76-bc0b-4b62-98b0-d041996a3e16.png',
 		speakerPicture: 'https://avatars2.githubusercontent.com/u/22420399?v=4',
-		titleSize: '50',
+		titleSize: 50,
 	},
 };


### PR DESCRIPTION
## 🤔 Why do you want to make those changes?

Add a color input to change the text color of the speaker name in the Talk template (Fix #1140)

## 🧪 How to check them?

Try to change color on the preview
