### PR TITLE
refactor(compositions): enhance Meetup and Talk compositions

### DIFF
--- a/remotion/compositions/templates/meetup/Meetup.composition.tsx
+++ b/remotion/compositions/templates/meetup/Meetup.composition.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import {Composition, Folder} from 'remotion';
 
-import {Meetup} from './Meetup';
+import {Meetup, MeetupSchema} from './Meetup';
 import {Register} from './Register';
 
 export const MeetupComposition: React.FC = () => {
@@ -14,9 +14,14 @@ export const MeetupComposition: React.FC = () => {
 				id="Meetup"
 				fps={30}
 				durationInFrames={270}
+				schema={MeetupSchema}
 				defaultProps={{
 					title: '#76 - LyonJS de la rentrée 🦁',
 					date: '28 septembre 2022',
+					backgroundImg:
+						'https://github.com/lyonjs/shortvid.io/blob/48ffea960b300eb9230786ed0ab043ec3387e877/public/images/showcases/lyonjs/defaultBackgroundImage.jpeg?raw=true',
+					eventLogo:
+						'https://github.com/lyonjs/shortvid.io/blob/main/public/images/showcases/lyonjs/lyonjsSquaredLogo.png?raw=true',
 				}}
 			/>
 			<Composition

--- a/remotion/compositions/templates/meetup/Meetup.tsx
+++ b/remotion/compositions/templates/meetup/Meetup.tsx
@@ -1,19 +1,23 @@
 import React from 'react';
+import {loadFont} from '@remotion/google-fonts/OpenSans';
 import {AbsoluteFill, Sequence, staticFile} from 'remotion';
+import {z} from 'zod';
 
 import {MeetupBackground} from './MeetupBackground';
 import {MeetupDate} from './MeetupDate';
 import {MeetupPresentation} from './MeetupPresentation';
 import {Register} from './Register';
 
-export type MeetupProps = {
-	eventLogo?: string;
-	backgroundImg?: string;
-	title: string;
-	date?: string;
-};
+const {fontFamily} = loadFont();
 
-export const Meetup: React.FC<MeetupProps> = ({
+export const MeetupSchema = z.object({
+	backgroundImg: z.string().optional(),
+	title: z.string(),
+	date: z.string().optional(),
+	eventLogo: z.string().optional(),
+});
+
+export const Meetup: React.FC<z.infer<typeof MeetupSchema>> = ({
 	backgroundImg = staticFile(
 		'/images/showcases/lyonjs/defaultBackgroundImage.jpeg',
 	),
@@ -25,6 +29,7 @@ export const Meetup: React.FC<MeetupProps> = ({
 		<AbsoluteFill
 			style={{
 				overflow: 'hidden',
+				fontFamily,
 			}}
 		>
 			<MeetupBackground backgroundImg={backgroundImg} />

--- a/remotion/compositions/templates/talk/Talk.tsx
+++ b/remotion/compositions/templates/talk/Talk.tsx
@@ -1,22 +1,17 @@
 import React from 'react';
+import {loadFont} from '@remotion/google-fonts/OpenSans';
 import {AbsoluteFill, Sequence, staticFile} from 'remotion';
+import {z} from 'zod';
 
 import {EventLogo} from '../../../design/atoms/EventLogo';
 
 import {SpeakerAndTitle} from './SpeakerAndTitle';
 import {TalkBackground} from './TalkBackground';
+import {TalkSchema} from './talks.types';
 
-export type TalkProps = {
-	eventLogo?: string;
-	speakersNames: string;
-	talkTitle: string;
-	backgroundImg?: string;
-	speakerPicture?: string;
-	titleSize?: number;
-	titleColor?: string;
-};
+const {fontFamily} = loadFont();
 
-export const Talk: React.FC<TalkProps> = ({
+export const Talk: React.FC<z.infer<typeof TalkSchema>> = ({
 	eventLogo,
 	speakersNames,
 	talkTitle,
@@ -31,6 +26,7 @@ export const Talk: React.FC<TalkProps> = ({
 		<AbsoluteFill
 			style={{
 				overflow: 'hidden',
+				fontFamily,
 			}}
 		>
 			<Sequence name="Background">

--- a/remotion/compositions/templates/talk/Talks.composition.tsx
+++ b/remotion/compositions/templates/talk/Talks.composition.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import {Composition, Folder, staticFile} from 'remotion';
+import {Composition, Folder} from 'remotion';
 
 import {TalkBranded} from './branded/TalkBranded';
 import {Talk} from './Talk';
@@ -14,29 +14,21 @@ export const TalksComposition: React.FC = () => {
 				component={Talk}
 				width={1200}
 				height={1200}
-				id="TalkWithPicture"
-				fps={30}
-				durationInFrames={120}
-				schema={TalkSchema}
-				defaultProps={{
-					speakersNames: 'John Doe',
-					talkTitle: 'Is JS an awesome programing language ?',
-					speakerPicture: staticFile(
-						'/images/showcases/lyonjs/lyonjsSquaredLogo.png',
-					),
-				}}
-			/>
-			<Composition
-				component={Talk}
-				width={1200}
-				height={1200}
 				id="Talk"
 				fps={30}
 				durationInFrames={120}
 				schema={TalkSchema}
 				defaultProps={{
-					speakersNames: 'Foo bar',
-					talkTitle: 'Is JS an awesome programing language?',
+					speakersNames: 'John Doe',
+					titleColor: '#efdb50',
+					talkTitle: 'Is JS an awesome programing language ?',
+					titleSize: 80,
+					backgroundImg:
+						'https://github.com/lyonjs/shortvid.io/blob/48ffea960b300eb9230786ed0ab043ec3387e877/public/images/showcases/lyonjs/defaultBackgroundImage.jpeg?raw=true',
+					speakerPicture:
+						'https://raw.githubusercontent.com/lyonjs/shortvid.io/main/public/images/common/defaultAvatar.svg',
+					eventLogo:
+						'https://github.com/lyonjs/shortvid.io/blob/main/public/images/showcases/lyonjs/lyonjsSquaredLogo.png?raw=true',
 				}}
 			/>
 			<Composition

--- a/remotion/compositions/templates/talk/talks.types.ts
+++ b/remotion/compositions/templates/talk/talks.types.ts
@@ -23,6 +23,6 @@ export const TalkSchema = z.object({
 	talkTitle: z.string(),
 	backgroundImg: z.string().optional(),
 	speakerPicture: z.string().optional(),
-	titleSize: z.number().optional(),
+	titleSize: z.number().finite().positive().gte(30).optional(),
 	titleColor: zColor().optional(),
 });

--- a/remotion/design/atoms/EventLogo.tsx
+++ b/remotion/design/atoms/EventLogo.tsx
@@ -12,7 +12,7 @@ export const EventLogo = ({style, src}: EventLogoProps) => {
 	) : (
 		<Img
 			style={style}
-			src={staticFile('/images/showcases/lyonjs/lyonjsSquaredLogo.png')}
+			src={src || staticFile('/images/showcases/lyonjs/lyonjsSquaredLogo.png')}
 		/>
 	);
 };


### PR DESCRIPTION
## 🤔 Why do you want to make those changes?

<!--
Explain the context of your changes in order to let reviewer understand what explains them.
-->

I need to prepare some meetup announcement posts for LyonJS but Meetup and Talk compositions were broken.

## 🧑‍🔬 How did you make them?

<!--
List your intention of action by doing this PR
-->

- force loading of open font 
- EventLogo now handle external logo url (it was not)
- Use Talk Schema as type
- Create meetup schema and use it as type
- pass all default variable as props of composition to help on the studio

## 🧪 How to check them?

<!--
Explain how reviewer could check that you did not break anything
-->

- run remotion start locally
